### PR TITLE
Pydicom as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "cloud_optimized_dicom/pydicom"]
+	path = cloud_optimized_dicom/pydicom
+	url = https://github.com/pydicom/pydicom.git

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,5 +7,8 @@
         "test_*.py"
     ],
     "python.testing.pytestEnabled": false,
-    "python.testing.unittestEnabled": true
+    "python.testing.unittestEnabled": true,
+    "python.analysis.extraPaths": [
+        "cloud_optimized_dicom/pydicom/src"
+    ]
 }

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include cloud_optimized_dicom/pydicom/src/pydicom *

--- a/cloud_optimized_dicom/__init__.py
+++ b/cloud_optimized_dicom/__init__.py
@@ -1,3 +1,23 @@
 __version__ = "0.1.0"
 __author__ = "Cal Nightingale"
 __credits__ = "Gradient Health"
+
+import importlib.metadata
+import os
+
+# monkeypatch in pydicom submodule
+import sys
+
+# Add vendored pydicom to sys.path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "pydicom", "src"))
+
+_real_version = importlib.metadata.version  # Save the real function
+
+
+def fake_version(name):
+    if name == "pydicom":
+        return "3.0.1"
+    return _real_version(name)
+
+
+importlib.metadata.version = fake_version

--- a/cloud_optimized_dicom/__init__.py
+++ b/cloud_optimized_dicom/__init__.py
@@ -21,3 +21,9 @@ def fake_version(name):
 
 
 importlib.metadata.version = fake_version
+
+pydicom3 = importlib.import_module("pydicom")
+
+# undo the patch now that we've imported pydicom
+importlib.metadata.version = _real_version
+sys.path.pop(0)

--- a/cloud_optimized_dicom/__init__.py
+++ b/cloud_optimized_dicom/__init__.py
@@ -1,29 +1,3 @@
 __version__ = "0.1.0"
 __author__ = "Cal Nightingale"
 __credits__ = "Gradient Health"
-
-import importlib.metadata
-import os
-
-# monkeypatch in pydicom submodule
-import sys
-
-# Add vendored pydicom to sys.path
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "pydicom", "src"))
-
-_real_version = importlib.metadata.version  # Save the real function
-
-
-def fake_version(name):
-    if name == "pydicom":
-        return "3.0.1"
-    return _real_version(name)
-
-
-importlib.metadata.version = fake_version
-
-pydicom3 = importlib.import_module("pydicom")
-
-# undo the patch now that we've imported pydicom
-importlib.metadata.version = _real_version
-sys.path.pop(0)

--- a/cloud_optimized_dicom/custom_offset_tables.py
+++ b/cloud_optimized_dicom/custom_offset_tables.py
@@ -1,10 +1,10 @@
 import logging
 from typing import Generator, Tuple
 
-from pydicom import DataElement, Dataset
-from pydicom.errors import InvalidDicomError
-from pydicom.filebase import DicomBytesIO
-from pydicom.tag import Tag
+from cloud_optimized_dicom.pydicom.src.pydicom import DataElement, Dataset
+from cloud_optimized_dicom.pydicom.src.pydicom.errors import InvalidDicomError
+from cloud_optimized_dicom.pydicom.src.pydicom.filebase import DicomBytesIO
+from cloud_optimized_dicom.pydicom.src.pydicom.tag import Tag
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)

--- a/cloud_optimized_dicom/instance.py
+++ b/cloud_optimized_dicom/instance.py
@@ -10,9 +10,9 @@ from ratarmountcore import open as rmc_open
 from smart_open import open as smart_open
 
 import cloud_optimized_dicom.metrics as metrics
-from cloud_optimized_dicom import pydicom3
 from cloud_optimized_dicom.custom_offset_tables import get_multiframe_offset_tables
 from cloud_optimized_dicom.hints import Hints
+from cloud_optimized_dicom.pydicom3 import DataElement, dcmread
 from cloud_optimized_dicom.utils import (
     DICOM_PREAMBLE,
     _delete_gcs_dep,
@@ -108,7 +108,7 @@ class Instance:
         """
         # populate all true values
         with self.open() as f:
-            with pydicom3.dcmread(f, defer_size=1024) as ds:
+            with dcmread(f, defer_size=1024) as ds:
                 self._instance_uid = getattr(ds, "SOPInstanceUID")
                 self._series_uid = getattr(ds, "SeriesInstanceUID")
                 self._study_uid = getattr(ds, "StudyInstanceUID")
@@ -327,12 +327,12 @@ class Instance:
         Extract metadata from the instance, populating self._metadata and self._custom_offset_tables
         """
         with self.open() as f:
-            with pydicom3.dcmread(f, defer_size=1024) as ds:
+            with dcmread(f, defer_size=1024) as ds:
                 # set custom offset tables
                 self._custom_offset_tables = get_multiframe_offset_tables(ds)
 
                 # define custom bulk data handler to include the head 512 bytes of overlarge elements
-                def bulk_data_handler(el: pydicom3.DataElement) -> str:
+                def bulk_data_handler(el: DataElement) -> str:
                     """Given a bulk data element, return a dict containing this instance's output_uri
                     and the head 512 bytes of the element"""
                     # TODO would be nice to find a way to include the tail 512 bytes as well

--- a/cloud_optimized_dicom/instance.py
+++ b/cloud_optimized_dicom/instance.py
@@ -6,11 +6,11 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Callable
 
-import pydicom
 from ratarmountcore import open as rmc_open
 from smart_open import open as smart_open
 
 import cloud_optimized_dicom.metrics as metrics
+import cloud_optimized_dicom.pydicom.src.pydicom as pydicom3
 from cloud_optimized_dicom.custom_offset_tables import get_multiframe_offset_tables
 from cloud_optimized_dicom.hints import Hints
 from cloud_optimized_dicom.utils import (
@@ -108,7 +108,7 @@ class Instance:
         """
         # populate all true values
         with self.open() as f:
-            with pydicom.dcmread(f, defer_size=1024) as ds:
+            with pydicom3.dcmread(f, defer_size=1024) as ds:
                 self._instance_uid = getattr(ds, "SOPInstanceUID")
                 self._series_uid = getattr(ds, "SeriesInstanceUID")
                 self._study_uid = getattr(ds, "StudyInstanceUID")
@@ -327,12 +327,12 @@ class Instance:
         Extract metadata from the instance, populating self._metadata and self._custom_offset_tables
         """
         with self.open() as f:
-            with pydicom.dcmread(f, defer_size=1024) as ds:
+            with pydicom3.dcmread(f, defer_size=1024) as ds:
                 # set custom offset tables
                 self._custom_offset_tables = get_multiframe_offset_tables(ds)
 
                 # define custom bulk data handler to include the head 512 bytes of overlarge elements
-                def bulk_data_handler(el: pydicom.DataElement) -> str:
+                def bulk_data_handler(el: pydicom3.DataElement) -> str:
                     """Given a bulk data element, return a dict containing this instance's output_uri
                     and the head 512 bytes of the element"""
                     # TODO would be nice to find a way to include the tail 512 bytes as well

--- a/cloud_optimized_dicom/instance.py
+++ b/cloud_optimized_dicom/instance.py
@@ -10,7 +10,7 @@ from ratarmountcore import open as rmc_open
 from smart_open import open as smart_open
 
 import cloud_optimized_dicom.metrics as metrics
-import cloud_optimized_dicom.pydicom.src.pydicom as pydicom3
+from cloud_optimized_dicom import pydicom3
 from cloud_optimized_dicom.custom_offset_tables import get_multiframe_offset_tables
 from cloud_optimized_dicom.hints import Hints
 from cloud_optimized_dicom.utils import (

--- a/cloud_optimized_dicom/pydicom3.py
+++ b/cloud_optimized_dicom/pydicom3.py
@@ -31,3 +31,5 @@ from pydicom.uid import generate_uid
 # undo the patch now that we've imported pydicom
 importlib.metadata.version = _real_version
 sys.path.pop(0)
+
+__version__ = "3.0.1"

--- a/cloud_optimized_dicom/pydicom3.py
+++ b/cloud_optimized_dicom/pydicom3.py
@@ -1,0 +1,33 @@
+import importlib.metadata
+import os
+
+# monkeypatch in pydicom submodule
+import sys
+
+# Add vendored pydicom to sys.path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "pydicom", "src"))
+
+_real_version = importlib.metadata.version  # Save the real function
+
+
+def fake_version(name):
+    if name == "pydicom":
+        return "3.0.1"
+    return _real_version(name)
+
+
+importlib.metadata.version = fake_version
+
+from pydicom.dataset import *
+from pydicom.encaps import encapsulate
+from pydicom.errors import InvalidDicomError
+
+# import pydicom modules that we need
+from pydicom.filebase import DicomBytesIO
+from pydicom.filereader import dcmread
+from pydicom.tag import Tag
+from pydicom.uid import generate_uid
+
+# undo the patch now that we've imported pydicom
+importlib.metadata.version = _real_version
+sys.path.pop(0)

--- a/cloud_optimized_dicom/tests/test_appender.py
+++ b/cloud_optimized_dicom/tests/test_appender.py
@@ -1,11 +1,20 @@
 import os
+import sys
 import unittest
+
+# Add pydicom submodule src directory to Python path
+from pathlib import Path
 from tempfile import NamedTemporaryFile
 
-import pydicom
+pydicom_src_dir = Path(__file__).parent.parent.parent / "pydicom" / "src" / "pydicom"
+if str(pydicom_src_dir) not in sys.path:
+    print(f"Adding to path: {pydicom_src_dir}")
+    sys.path.insert(0, str(pydicom_src_dir))
+
 from google.api_core.client_options import ClientOptions
 from google.cloud import storage
 
+import cloud_optimized_dicom.pydicom.src.pydicom as pydicom3
 from cloud_optimized_dicom.appender import CODAppender
 from cloud_optimized_dicom.cod_object import CODObject
 from cloud_optimized_dicom.hints import Hints
@@ -120,7 +129,7 @@ class TestAppender(unittest.TestCase):
         )
         # make a diff hash dupe
         with NamedTemporaryFile(suffix=".dcm") as f:
-            with pydicom.dcmread(self.local_instance_path) as ds:
+            with pydicom3.dcmread(self.local_instance_path) as ds:
                 ds.add_new((0x1234, 0x5678), "DS", "12345678")
                 ds.save_as(f.name)
             self.assertTrue(os.path.exists(f.name))
@@ -259,7 +268,7 @@ class TestAppender(unittest.TestCase):
 
         # create a corrupt dicom (has proper header but then is garbage)
         with NamedTemporaryFile(suffix=".dcm") as f:
-            with pydicom.FileDataset(
+            with pydicom3.FileDataset(
                 f.name, {}, is_little_endian=True, is_implicit_VR=False
             ) as ds:
                 ds.StudyInstanceUID = (

--- a/cloud_optimized_dicom/tests/test_appender.py
+++ b/cloud_optimized_dicom/tests/test_appender.py
@@ -5,11 +5,11 @@ from tempfile import NamedTemporaryFile
 from google.api_core.client_options import ClientOptions
 from google.cloud import storage
 
-from cloud_optimized_dicom import pydicom3
 from cloud_optimized_dicom.appender import CODAppender
 from cloud_optimized_dicom.cod_object import CODObject
 from cloud_optimized_dicom.hints import Hints
 from cloud_optimized_dicom.instance import Instance
+from cloud_optimized_dicom.pydicom3 import FileDataset, dcmread
 from cloud_optimized_dicom.utils import delete_uploaded_blobs
 
 
@@ -120,7 +120,7 @@ class TestAppender(unittest.TestCase):
         )
         # make a diff hash dupe
         with NamedTemporaryFile(suffix=".dcm") as f:
-            with pydicom3.dcmread(self.local_instance_path) as ds:
+            with dcmread(self.local_instance_path) as ds:
                 ds.add_new((0x1234, 0x5678), "DS", "12345678")
                 ds.save_as(f.name)
             self.assertTrue(os.path.exists(f.name))
@@ -259,7 +259,7 @@ class TestAppender(unittest.TestCase):
 
         # create a corrupt dicom (has proper header but then is garbage)
         with NamedTemporaryFile(suffix=".dcm") as f:
-            with pydicom3.FileDataset(
+            with FileDataset(
                 f.name, {}, is_little_endian=True, is_implicit_VR=False
             ) as ds:
                 ds.StudyInstanceUID = (

--- a/cloud_optimized_dicom/tests/test_appender.py
+++ b/cloud_optimized_dicom/tests/test_appender.py
@@ -5,7 +5,7 @@ from tempfile import NamedTemporaryFile
 from google.api_core.client_options import ClientOptions
 from google.cloud import storage
 
-import cloud_optimized_dicom.pydicom.src.pydicom as pydicom3
+from cloud_optimized_dicom import pydicom3
 from cloud_optimized_dicom.appender import CODAppender
 from cloud_optimized_dicom.cod_object import CODObject
 from cloud_optimized_dicom.hints import Hints

--- a/cloud_optimized_dicom/tests/test_appender.py
+++ b/cloud_optimized_dicom/tests/test_appender.py
@@ -1,15 +1,6 @@
 import os
-import sys
 import unittest
-
-# Add pydicom submodule src directory to Python path
-from pathlib import Path
 from tempfile import NamedTemporaryFile
-
-pydicom_src_dir = Path(__file__).parent.parent.parent / "pydicom" / "src" / "pydicom"
-if str(pydicom_src_dir) not in sys.path:
-    print(f"Adding to path: {pydicom_src_dir}")
-    sys.path.insert(0, str(pydicom_src_dir))
 
 from google.api_core.client_options import ClientOptions
 from google.cloud import storage

--- a/cloud_optimized_dicom/tests/test_concat.py
+++ b/cloud_optimized_dicom/tests/test_concat.py
@@ -8,7 +8,7 @@ from google.api_core.client_options import ClientOptions
 from google.cloud import storage
 from google.cloud.storage.retry import DEFAULT_RETRY
 
-import cloud_optimized_dicom.pydicom.src.pydicom as pydicom3
+from cloud_optimized_dicom import pydicom3
 from cloud_optimized_dicom.cod_object import CODObject
 from cloud_optimized_dicom.instance import Hints, Instance
 from cloud_optimized_dicom.query_parsing import query_result_to_codobjects

--- a/cloud_optimized_dicom/tests/test_concat.py
+++ b/cloud_optimized_dicom/tests/test_concat.py
@@ -4,11 +4,11 @@ import os
 import tempfile
 import unittest
 
-import pydicom
 from google.api_core.client_options import ClientOptions
 from google.cloud import storage
 from google.cloud.storage.retry import DEFAULT_RETRY
 
+import cloud_optimized_dicom.pydicom.src.pydicom as pydicom3
 from cloud_optimized_dicom.cod_object import CODObject
 from cloud_optimized_dicom.instance import Hints, Instance
 from cloud_optimized_dicom.query_parsing import query_result_to_codobjects
@@ -175,7 +175,7 @@ class TestConcat(unittest.TestCase):
                     data = tar.read(
                         instance._byte_offsets[1] - instance._byte_offsets[0]
                     )
-                    with pydicom.dcmread(io.BytesIO(data)) as ds:
+                    with pydicom3.dcmread(io.BytesIO(data)) as ds:
                         self.assertEqual(ds.SOPInstanceUID, instance.instance_uid())
 
     def test_dupe_instance(self):
@@ -260,11 +260,11 @@ class TestConcat(unittest.TestCase):
         v2_blob = storage.Blob.from_string(v2_uri, client=self.client)
         v1_blob.upload_from_filename(dcm_path)
         # change something (cause hash mismatch)
-        ds = pydicom.dcmread(dcm_path)
+        ds = pydicom3.dcmread(dcm_path)
         study_uid = getattr(ds, "StudyInstanceUID")
         series_uid = getattr(ds, "SeriesInstanceUID")
         instance_uid = getattr(ds, "SOPInstanceUID")
-        ds.add_new(pydicom.tag.Tag(0x6001, 0x0010), "LO", "Gradient Health")
+        ds.add_new(pydicom3.tag.Tag(0x6001, 0x0010), "LO", "Gradient Health")
         with tempfile.NamedTemporaryFile() as temp_file:
             ds.save_as(temp_file.name)
             v2_blob.upload_from_filename(temp_file.name)

--- a/cloud_optimized_dicom/tests/test_concat.py
+++ b/cloud_optimized_dicom/tests/test_concat.py
@@ -8,9 +8,9 @@ from google.api_core.client_options import ClientOptions
 from google.cloud import storage
 from google.cloud.storage.retry import DEFAULT_RETRY
 
-from cloud_optimized_dicom import pydicom3
 from cloud_optimized_dicom.cod_object import CODObject
 from cloud_optimized_dicom.instance import Hints, Instance
+from cloud_optimized_dicom.pydicom3 import FileDataset, Tag, dcmread
 from cloud_optimized_dicom.query_parsing import query_result_to_codobjects
 from cloud_optimized_dicom.series_metadata import SeriesMetadata
 from cloud_optimized_dicom.utils import delete_uploaded_blobs
@@ -175,7 +175,7 @@ class TestConcat(unittest.TestCase):
                     data = tar.read(
                         instance._byte_offsets[1] - instance._byte_offsets[0]
                     )
-                    with pydicom3.dcmread(io.BytesIO(data)) as ds:
+                    with dcmread(io.BytesIO(data)) as ds:
                         self.assertEqual(ds.SOPInstanceUID, instance.instance_uid())
 
     def test_dupe_instance(self):
@@ -260,11 +260,11 @@ class TestConcat(unittest.TestCase):
         v2_blob = storage.Blob.from_string(v2_uri, client=self.client)
         v1_blob.upload_from_filename(dcm_path)
         # change something (cause hash mismatch)
-        ds = pydicom3.dcmread(dcm_path)
+        ds = dcmread(dcm_path)
         study_uid = getattr(ds, "StudyInstanceUID")
         series_uid = getattr(ds, "SeriesInstanceUID")
         instance_uid = getattr(ds, "SOPInstanceUID")
-        ds.add_new(pydicom3.tag.Tag(0x6001, 0x0010), "LO", "Gradient Health")
+        ds.add_new(Tag(0x6001, 0x0010), "LO", "Gradient Health")
         with tempfile.NamedTemporaryFile() as temp_file:
             ds.save_as(temp_file.name)
             v2_blob.upload_from_filename(temp_file.name)

--- a/cloud_optimized_dicom/tests/test_custom_offset_tables.py
+++ b/cloud_optimized_dicom/tests/test_custom_offset_tables.py
@@ -3,12 +3,12 @@ from io import BytesIO
 from unittest.mock import patch
 
 import numpy as np
-from pydicom.dataset import Dataset, FileMetaDataset
-from pydicom.encaps import encapsulate
-from pydicom.errors import InvalidDicomError
-from pydicom.uid import generate_uid
 
 from cloud_optimized_dicom.custom_offset_tables import get_multiframe_offset_tables
+from cloud_optimized_dicom.pydicom.src.pydicom.dataset import Dataset, FileMetaDataset
+from cloud_optimized_dicom.pydicom.src.pydicom.encaps import encapsulate
+from cloud_optimized_dicom.pydicom.src.pydicom.errors import InvalidDicomError
+from cloud_optimized_dicom.pydicom.src.pydicom.uid import generate_uid
 
 
 def _generate_random_pixel_data(length: int) -> bytes:

--- a/cloud_optimized_dicom/tests/test_custom_offset_tables.py
+++ b/cloud_optimized_dicom/tests/test_custom_offset_tables.py
@@ -4,11 +4,8 @@ from unittest.mock import patch
 
 import numpy as np
 
+from cloud_optimized_dicom import pydicom3
 from cloud_optimized_dicom.custom_offset_tables import get_multiframe_offset_tables
-from cloud_optimized_dicom.pydicom.src.pydicom.dataset import Dataset, FileMetaDataset
-from cloud_optimized_dicom.pydicom.src.pydicom.encaps import encapsulate
-from cloud_optimized_dicom.pydicom.src.pydicom.errors import InvalidDicomError
-from cloud_optimized_dicom.pydicom.src.pydicom.uid import generate_uid
 
 
 def _generate_random_pixel_data(length: int) -> bytes:
@@ -21,7 +18,7 @@ def create_sample_dataset(
     is_pixeldata_encapsulated=True,
     include_eot=False,
     include_bot=False,
-) -> Dataset:
+) -> pydicom3.dataset.Dataset:
     """
     Creates a sample DICOM dataset.
 
@@ -34,25 +31,25 @@ def create_sample_dataset(
     Returns:
         pydicom.Dataset: A sample DICOM dataset created using the given parameters.
     """
-    file_meta = FileMetaDataset()
-    file_meta.MediaStorageSOPClassUID = generate_uid()
-    file_meta.MediaStorageSOPInstanceUID = generate_uid()
-    file_meta.TransferSyntaxUID = generate_uid()
+    file_meta = pydicom3.dataset.FileMetaDataset()
+    file_meta.MediaStorageSOPClassUID = pydicom3.uid.generate_uid()
+    file_meta.MediaStorageSOPInstanceUID = pydicom3.uid.generate_uid()
+    file_meta.TransferSyntaxUID = pydicom3.uid.generate_uid()
 
-    ds = Dataset()
+    ds = pydicom3.dataset.Dataset()
     ds.file_meta = file_meta
 
     ds.PatientName = "Test^Patient"
     ds.PatientID = "123456"
-    ds.StudyInstanceUID = generate_uid()
-    ds.SeriesInstanceUID = generate_uid()
-    ds.SOPInstanceUID = generate_uid()
+    ds.StudyInstanceUID = pydicom3.uid.generate_uid()
+    ds.SeriesInstanceUID = pydicom3.uid.generate_uid()
+    ds.SOPInstanceUID = pydicom3.uid.generate_uid()
     ds.NumberOfFrames = number_of_frames
 
     raw_pixeldata = [_generate_random_pixel_data(200) for _ in range(number_of_frames)]
 
     if is_pixeldata_encapsulated:
-        pixelData = encapsulate(raw_pixeldata, has_bot=include_bot)
+        pixelData = pydicom3.encaps.encapsulate(raw_pixeldata, has_bot=include_bot)
     else:
         pixelData = bytes([item for sublist in raw_pixeldata for item in sublist])
 
@@ -196,8 +193,8 @@ class TestMultiframeOffsetTable(unittest.TestCase):
             include_eot=False,
             include_bot=False,
         )
-        mock_generate_pixel_data_fragment_offsets.side_effect = InvalidDicomError(
-            "Test error"
+        mock_generate_pixel_data_fragment_offsets.side_effect = (
+            pydicom3.errors.InvalidDicomError("Test error")
         )
 
         get_multiframe_offset_tables(dataset)

--- a/cloud_optimized_dicom/tests/test_hashed_uids.py
+++ b/cloud_optimized_dicom/tests/test_hashed_uids.py
@@ -5,10 +5,10 @@ from tempfile import NamedTemporaryFile
 from google.api_core.client_options import ClientOptions
 from google.cloud import storage
 
-from cloud_optimized_dicom import pydicom3
 from cloud_optimized_dicom.cod_object import CODObject
 from cloud_optimized_dicom.hints import Hints
 from cloud_optimized_dicom.instance import Instance
+from cloud_optimized_dicom.pydicom3 import FileDataset, Tag, dcmread
 
 
 def example_hash_function(uid: str) -> str:
@@ -185,7 +185,7 @@ class TestDeid(unittest.TestCase):
         self.assertEqual(append_result.new[0], instance)
         # make a diff hash dupe
         with NamedTemporaryFile(suffix=".dcm") as f:
-            with pydicom3.dcmread(self.local_instance_path) as ds:
+            with dcmread(self.local_instance_path) as ds:
                 ds.add_new((0x1234, 0x5678), "DS", "12345678")
                 ds.save_as(f.name)
             diff_hash_dupe = Instance(

--- a/cloud_optimized_dicom/tests/test_hashed_uids.py
+++ b/cloud_optimized_dicom/tests/test_hashed_uids.py
@@ -2,10 +2,10 @@ import os
 import unittest
 from tempfile import NamedTemporaryFile
 
-import pydicom
 from google.api_core.client_options import ClientOptions
 from google.cloud import storage
 
+import cloud_optimized_dicom.pydicom.src.pydicom as pydicom3
 from cloud_optimized_dicom.cod_object import CODObject
 from cloud_optimized_dicom.hints import Hints
 from cloud_optimized_dicom.instance import Instance
@@ -185,7 +185,7 @@ class TestDeid(unittest.TestCase):
         self.assertEqual(append_result.new[0], instance)
         # make a diff hash dupe
         with NamedTemporaryFile(suffix=".dcm") as f:
-            with pydicom.dcmread(self.local_instance_path) as ds:
+            with pydicom3.dcmread(self.local_instance_path) as ds:
                 ds.add_new((0x1234, 0x5678), "DS", "12345678")
                 ds.save_as(f.name)
             diff_hash_dupe = Instance(

--- a/cloud_optimized_dicom/tests/test_hashed_uids.py
+++ b/cloud_optimized_dicom/tests/test_hashed_uids.py
@@ -5,7 +5,7 @@ from tempfile import NamedTemporaryFile
 from google.api_core.client_options import ClientOptions
 from google.cloud import storage
 
-import cloud_optimized_dicom.pydicom.src.pydicom as pydicom3
+from cloud_optimized_dicom import pydicom3
 from cloud_optimized_dicom.cod_object import CODObject
 from cloud_optimized_dicom.hints import Hints
 from cloud_optimized_dicom.instance import Instance

--- a/cloud_optimized_dicom/tests/test_instance.py
+++ b/cloud_optimized_dicom/tests/test_instance.py
@@ -3,8 +3,8 @@ import tarfile
 import tempfile
 import unittest
 
-from cloud_optimized_dicom import pydicom3
 from cloud_optimized_dicom.instance import Instance
+from cloud_optimized_dicom.pydicom3 import FileDataset, Tag, dcmread
 from cloud_optimized_dicom.utils import is_remote
 
 
@@ -25,13 +25,13 @@ class TestInstance(unittest.TestCase):
     def test_local_open(self):
         instance = Instance(self.local_instance_path)
         with instance.open() as f:
-            ds = pydicom3.dcmread(f)
+            ds = dcmread(f)
             self.assertEqual(ds.SOPInstanceUID, self.test_instance_uid)
 
     def test_remote_open(self):
         instance = Instance(self.remote_dicom_uri)
         with instance.open() as f:
-            ds = pydicom3.dcmread(f)
+            ds = dcmread(f)
             self.assertEqual(ds.SOPInstanceUID, self.test_instance_uid)
 
     def test_validate(self):
@@ -116,7 +116,7 @@ class TestInstance(unittest.TestCase):
         self.assertIsNotNone(instance._temp_file)
         # make sure we can read the instance
         with instance.open() as f:
-            ds = pydicom3.dcmread(f)
+            ds = dcmread(f)
             self.assertEqual(ds.SOPInstanceUID, self.test_instance_uid)
         # delete the instance - this should clean up the temp file
         del instance

--- a/cloud_optimized_dicom/tests/test_instance.py
+++ b/cloud_optimized_dicom/tests/test_instance.py
@@ -3,7 +3,7 @@ import tarfile
 import tempfile
 import unittest
 
-import cloud_optimized_dicom.pydicom.src.pydicom as pydicom3
+from cloud_optimized_dicom import pydicom3
 from cloud_optimized_dicom.instance import Instance
 from cloud_optimized_dicom.utils import is_remote
 

--- a/cloud_optimized_dicom/tests/test_instance.py
+++ b/cloud_optimized_dicom/tests/test_instance.py
@@ -3,8 +3,7 @@ import tarfile
 import tempfile
 import unittest
 
-import pydicom
-
+import cloud_optimized_dicom.pydicom.src.pydicom as pydicom3
 from cloud_optimized_dicom.instance import Instance
 from cloud_optimized_dicom.utils import is_remote
 
@@ -26,13 +25,13 @@ class TestInstance(unittest.TestCase):
     def test_local_open(self):
         instance = Instance(self.local_instance_path)
         with instance.open() as f:
-            ds = pydicom.dcmread(f)
+            ds = pydicom3.dcmread(f)
             self.assertEqual(ds.SOPInstanceUID, self.test_instance_uid)
 
     def test_remote_open(self):
         instance = Instance(self.remote_dicom_uri)
         with instance.open() as f:
-            ds = pydicom.dcmread(f)
+            ds = pydicom3.dcmread(f)
             self.assertEqual(ds.SOPInstanceUID, self.test_instance_uid)
 
     def test_validate(self):
@@ -117,7 +116,7 @@ class TestInstance(unittest.TestCase):
         self.assertIsNotNone(instance._temp_file)
         # make sure we can read the instance
         with instance.open() as f:
-            ds = pydicom.dcmread(f)
+            ds = pydicom3.dcmread(f)
             self.assertEqual(ds.SOPInstanceUID, self.test_instance_uid)
         # delete the instance - this should clean up the temp file
         del instance

--- a/cloud_optimized_dicom/tests/test_pydicom.py
+++ b/cloud_optimized_dicom/tests/test_pydicom.py
@@ -1,0 +1,14 @@
+import unittest
+
+
+class TestPydicom(unittest.TestCase):
+    def test_pydicom_version(self):
+        """
+        Test that the pydicom version is 2.3.0 and the pydicom3 version is 3.0.1
+        """
+        from pydicom import __version__ as locally_installed_pd_version
+
+        from cloud_optimized_dicom.pydicom3 import __version__ as repo_pd_version
+
+        self.assertEqual(locally_installed_pd_version, "2.3.0")
+        self.assertEqual(repo_pd_version, "3.0.1")

--- a/setup.py
+++ b/setup.py
@@ -21,4 +21,9 @@ setup(
         "apache-beam[gcp]==2.63.0",
         "filetype==1.2.0",
     ],
+    extras_require={
+        "test": [
+            "pydicom==2.3.0",
+        ],
+    },
 )

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup
+from setuptools import find_packages, setup
 
 setup(
     name="cloud-optimized-dicom",
@@ -8,7 +8,11 @@ setup(
     author="Cal Nightingale",
     author_email="cal@gradienthealth.io",
     license="MIT",
-    packages=["cloud_optimized_dicom"],
+    packages=find_packages(),
+    include_package_data=True,
+    package_data={
+        "": ["pydicom/src/pydicom/**/*"],
+    },
     install_requires=[
         "smart-open==7.1.0",
         "ratarmountcore==0.8.0",

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,6 @@ setup(
     license="MIT",
     packages=["cloud_optimized_dicom"],
     install_requires=[
-        "pydicom",
         "smart-open==7.1.0",
         "ratarmountcore==0.8.0",
         "numpy",


### PR DESCRIPTION
- Add pydicom version `3.0.1` as a submodule
- create "pseudo-module" `cloud_optimized_dicom.pydicom3`: Add vendored pydicom path to `sys.path`, Patch importlib.metadata.version to return `3.0.1` if `name=="pydicom"`, import stuff from pydicom COD needs, undo patch
- update imports/pydicom usage throughout codebase to import from this submodule
- removed pydicom as a listed dependency of the package