### PR TITLE
Instances can be read after sync

### DIFF
--- a/cloud_optimized_dicom/tests/test_concat.py
+++ b/cloud_optimized_dicom/tests/test_concat.py
@@ -155,10 +155,11 @@ class TestConcat(unittest.TestCase):
         self.assertTrue(
             metadata_blob.exists(), f"{cod_obj.metadata_uri} does not exist"
         )
+        metadata = SeriesMetadata.from_blob(metadata_blob)
         if not dryrun:
             for instance in new + same:
                 instance.delete_dependencies()
-            self._assert_instances_dne(cod_obj._metadata.instances.values())
+            self._assert_instances_dne(metadata.instances.values())
         return cod_obj
 
     def test_single_instance(self):

--- a/cloud_optimized_dicom/utils.py
+++ b/cloud_optimized_dicom/utils.py
@@ -144,7 +144,9 @@ def public_method(func):
                     "Cannot perform clean operation on unlocked CODObject"
                 )
         elif self.lock:
-            logger.warning(f"Performing dirty operation on locked CODObject: {self}")
+            logger.warning(
+                f"Performing dirty operation '{func.__name__}' on locked CODObject: {self}"
+            )
         return func(self, *args, **kwargs)
 
     return wrapper


### PR DESCRIPTION
Because we set the instance.dicom_uri to be remote prior to metadata upload, if you ran sync() a CODObject and then tried to do instance.open(), it would error because the URI would be a remote tar. This PR sets the dicom_uris back to local after metadata sync, so the instances remember they've already been fetched