### PR TITLE
CODObj.get_custom_tag dirtiness based on CODObj.lock value

### DIFF
--- a/cloud_optimized_dicom/cod_object.py
+++ b/cloud_optimized_dicom/cod_object.py
@@ -106,7 +106,9 @@ class CODObject:
         self._tar_synced = _tar_synced
         self._metadata_synced = _metadata_synced
         # if the thumbnail exists, it is not synced (we did not fetch it)
-        self._thumbnail_synced = self.get_custom_tag("thumbnail", dirty=True) is None
+        self._thumbnail_synced = (
+            self.get_custom_tag("thumbnail", dirty=not lock) is None
+        )
 
     def _validate_uids(self):
         """Validate the UIDs are valid DICOM UIDs (TODO make this more robust, for now just check length)"""


### PR DESCRIPTION
Avoids warnings about dirty operations on locked cod objects when fetching thumbnail metadata to determine if thumbnail is synced