### PR TITLE
Make instances pickleable

### DIFF
--- a/cloud_optimized_dicom/instance.py
+++ b/cloud_optimized_dicom/instance.py
@@ -86,9 +86,8 @@ class Instance:
             return
 
         # we store the path, not the file object, so that instances can be pickled (allows them to be passed between beam.DoFns)
-        self._temp_file_path = tempfile.NamedTemporaryFile(
-            suffix=".dcm", delete=False
-        ).name
+        with tempfile.NamedTemporaryFile(suffix=".dcm", delete=False) as temp_file:
+            self._temp_file_path = temp_file.name
 
         # read remote file into local temp file
         with open(self._temp_file_path, "wb") as local_file:

--- a/cloud_optimized_dicom/tests/test_instance.py
+++ b/cloud_optimized_dicom/tests/test_instance.py
@@ -115,8 +115,8 @@ class TestInstance(unittest.TestCase):
             ) as in_file:
                 out.write(in_file.read())
         # make an instance with the temp file
-        instance = Instance(dicom_uri=temp_file.name, _temp_file=temp_file)
-        self.assertIsNotNone(instance._temp_file)
+        instance = Instance(dicom_uri=temp_file.name, _temp_file_path=temp_file.name)
+        self.assertIsNotNone(instance._temp_file_path)
         # make sure we can read the instance
         with instance.open() as f:
             ds = pydicom3.dcmread(f)


### PR DESCRIPTION
By storing the temp file path, not the temp file object, we allow instances to be pickeled