### PR TITLE
Fix empty tar detection

### DIFF
--- a/cloud_optimized_dicom/cod_object.py
+++ b/cloud_optimized_dicom/cod_object.py
@@ -31,8 +31,6 @@ from cloud_optimized_dicom.utils import (
 
 logger = logging.getLogger(__name__)
 
-EMPTY_TAR_SIZE = 10240
-
 
 class CODObject:
     """
@@ -144,7 +142,8 @@ class CODObject:
     @property
     def tar_is_empty(self) -> bool:
         """Check if the tar file is empty."""
-        return os.path.getsize(self.tar_file_path) == EMPTY_TAR_SIZE
+        with tarfile.open(self.tar_file_path, "r") as tar:
+            return len(tar.getmembers()) == 0
 
     @property
     def index_file_path(self) -> str:

--- a/cloud_optimized_dicom/locker.py
+++ b/cloud_optimized_dicom/locker.py
@@ -32,12 +32,13 @@ class CODLocker:
         # if the lock already exists, assert generation matches (re-acquisition case)
         if (lock_blob := self.get_lock_blob()).exists():
             lock_blob.reload()
+            lock_uri = f"gs://{lock_blob.bucket.name}/{lock_blob.name}"
             if lock_blob.generation != self.cod_object.lock_generation:
                 raise LockAcquisitionError(
-                    "COD:LOCK:ACQUISITION_FAILED:DIFF_GEN_LOCK_ALREADY_EXISTS"
+                    f"COD:LOCK:ACQUISITION_FAILED:DIFF_GEN_LOCK_ALREADY_EXISTS:{lock_uri} (generation: {lock_blob.generation})"
                 )
             logger.info(
-                f"COD:LOCK:REACQUIRED:gs://{lock_blob.bucket.name}/{lock_blob.name} (generation: {self.cod_object.lock_generation})"
+                f"COD:LOCK:REACQUIRED:{lock_uri} (generation: {self.cod_object.lock_generation})"
             )
             return
 


### PR DESCRIPTION
Previously, COD relied on a constant EMPTY_TAR_SIZE to determine whether a tar was empty, for the purposes of syncing it. This approach seems to have been unreliable for very small dicom files. COD now relies on the `len(tar.getmembers())` field, which is more consistent, when determining whether the tar is empty