### PR TITLE
Fix _metadata AttributeError in CODObject.__init__

### DIFF
--- a/cloud_optimized_dicom/cod_object.py
+++ b/cloud_optimized_dicom/cod_object.py
@@ -128,6 +128,8 @@ class CODObject:
                 raise ErrorLogExistsError(
                     f"Cannot initialize; error log exists: {self.error_log_uri}"
                 )
+        # Initialize _metadata before locker, since acquire() calls get_metadata()
+        self._metadata = None
         # Only acquire lock for write/append mode WITH sync_on_exit=True
         # sync_on_exit=False means no lock (efficient for testing)
         self._locker = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cloud-optimized-dicom"
-version = "0.2.3"
+version = "0.2.4"
 description = "A library for efficiently storing and interacting with DICOM files in the cloud"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
## Summary
- Initialize `self._metadata = None` before `locker.acquire()`, which calls `get_metadata()` → `_get_metadata()` that accesses `self._metadata`
- Without this, all CODObject construction in write/append/read modes crashes with `AttributeError: 'CODObject' object has no attribute '_metadata'`
- Caused 36 errors and 4 failures across the test suite (masked by the CI bug fixed in #93)

## Test plan
- [ ] CI passes (now properly enforced with pipefail from #93)

🤖 Generated with [Claude Code](https://claude.com/claude-code)