### PR TITLE
PROC-1502: Backfill dropped UID tags in Instance.extract_metadata

### DIFF
--- a/cloud_optimized_dicom/instance.py
+++ b/cloud_optimized_dicom/instance.py
@@ -441,8 +441,21 @@ class Instance:
                         bulk_data_element_handler=bulk_data_handler
                     )
                 )
+                self._backfill_missing_uids(ds_dict)
                 # populate self._dicom_metadata with uncompressed metadata
                 self._dicom_metadata = DicomMetadata(ds_dict)
+
+    def _backfill_missing_uids(self, ds_dict: dict) -> None:
+        """Reinsert critical UID tags dropped by `to_json_dict(suppress_invalid_tags=True)`
+        when values are non-conformant (e.g. leading-zero components, >64 chars)."""
+        uid_sources = {
+            "0020000D": self._study_uid,
+            "0020000E": self._series_uid,
+            "00080018": self._instance_uid,
+        }
+        for tag, cached_value in uid_sources.items():
+            if tag not in ds_dict and cached_value is not None:
+                ds_dict[tag] = {"vr": "UI", "Value": [cached_value]}
 
     def get_pixeldata_hash(self) -> str:
         """Compute the crc32c hash of just the pixeldata"""

--- a/cloud_optimized_dicom/instance.py
+++ b/cloud_optimized_dicom/instance.py
@@ -7,6 +7,7 @@ from typing import Callable, Optional
 
 import pydicom3
 import pydicom3.uid
+from pydicom3.datadict import tag_for_keyword
 from ratarmountcore import open as rmc_open
 from smart_open import open as smart_open
 
@@ -28,6 +29,10 @@ from cloud_optimized_dicom.virtual_file import VirtualFile
 
 TAR_IDENTIFIER = ".tar://"
 ZIP_IDENTIFIER = ".zip://"
+
+_STUDY_INSTANCE_UID_TAG = f"{tag_for_keyword('StudyInstanceUID'):08X}"
+_SERIES_INSTANCE_UID_TAG = f"{tag_for_keyword('SeriesInstanceUID'):08X}"
+_SOP_INSTANCE_UID_TAG = f"{tag_for_keyword('SOPInstanceUID'):08X}"
 
 
 @dataclass
@@ -449,9 +454,9 @@ class Instance:
         """Reinsert critical UID tags dropped by `to_json_dict(suppress_invalid_tags=True)`
         when values are non-conformant (e.g. leading-zero components, >64 chars)."""
         uid_sources = {
-            "0020000D": self._study_uid,
-            "0020000E": self._series_uid,
-            "00080018": self._instance_uid,
+            _STUDY_INSTANCE_UID_TAG: self._study_uid,
+            _SERIES_INSTANCE_UID_TAG: self._series_uid,
+            _SOP_INSTANCE_UID_TAG: self._instance_uid,
         }
         for tag, cached_value in uid_sources.items():
             if tag not in ds_dict and cached_value is not None:

--- a/cloud_optimized_dicom/tests/test_instance.py
+++ b/cloud_optimized_dicom/tests/test_instance.py
@@ -91,6 +91,39 @@ class TestInstance(unittest.TestCase):
         )
         self.assertEqual(instance._custom_offset_tables, {})
 
+    def test_extract_metadata_backfills_invalid_uid(self):
+        """Non-conformant UIDs (e.g. leading-zero components, >64 chars) are
+        dropped by pydicom3 when `to_json_dict(suppress_invalid_tags=True)`
+        serializes under strict_reading. _backfill_missing_uids must reinsert
+        them from the cached Instance fields populated by validate()."""
+        bad_study_uid = "1.2.840.01.2.3"  # leading zero component
+        bad_series_uid = "1.2.840.10008.5.1.4.1.2.A"  # non-digit component
+        bad_sop_uid = "1." + "2" * 70  # >64 chars
+
+        with tempfile.NamedTemporaryFile(suffix=".dcm") as tmp:
+            ds = pydicom3.dcmread(self.local_instance_path)
+            ds.StudyInstanceUID = bad_study_uid
+            ds.SeriesInstanceUID = bad_series_uid
+            ds.SOPInstanceUID = bad_sop_uid
+            ds.file_meta.MediaStorageSOPInstanceUID = bad_sop_uid
+            ds.save_as(tmp.name, write_like_original=False)
+
+            instance = Instance(tmp.name)
+            instance.validate()
+            self.assertEqual(instance._study_uid, bad_study_uid)
+            self.assertEqual(instance._series_uid, bad_series_uid)
+            self.assertEqual(instance._instance_uid, bad_sop_uid)
+
+            instance.extract_metadata(
+                output_uri="gs://some_series.tar://instances/some_instance.dcm"
+            )
+
+            # Without the backfill, these tags would be missing from the JSON
+            # dict because to_json_dict(suppress_invalid_tags=True) drops them.
+            self.assertEqual(instance.metadata["0020000D"]["Value"][0], bad_study_uid)
+            self.assertEqual(instance.metadata["0020000E"]["Value"][0], bad_series_uid)
+            self.assertEqual(instance.metadata["00080018"]["Value"][0], bad_sop_uid)
+
     def test_delete_local_dependencies(self):
         temp_file = tempfile.NamedTemporaryFile(delete=False)
         self.assertTrue(os.path.exists(temp_file.name))


### PR DESCRIPTION
## Summary

Fixes the root cause of [PROC-1502](https://linear.app/gradienthealth/issue/PROC-1502): ~12.9k series across 8,445 studies have `NULL SeriesInstanceUID` in `fermat.public_table` because the tag is silently dropped from the COD `metadata.json` during ingestion, even though the original P10 file contains it.

## Root cause

`Instance.extract_metadata()` serializes the DICOM header via:

```python
ds_dict = ds.to_json_dict(
    bulk_data_element_handler=bulk_data_handler,
    suppress_invalid_tags=True,
)
```

`suppress_invalid_tags=True` activates pydicom3's `config.strict_reading()` context, which promotes value-validation *warnings* into *exceptions*. When an element (e.g. SeriesInstanceUID) is serialized and its value fails re-validation under strict mode, the enclosing try/except drops that tag from the output dict.

In practice, the affected series come from producers that emit **non-conformant UIDs**:
- leading-zero components (`1.2.840.01.2.3`)
- non-digit characters
- values longer than 64 chars

These are read by `pydicom3.dcmread` without strict mode (so they populate `_study_uid` / `_series_uid` / `_instance_uid` on the `Instance` just fine), but the JSON serialization under strict mode silently drops them. Downstream (`deid_dicom_header` → `prod_table` → `public_table`) inherits the NULL and propagates it.

## Fix

Added `Instance._backfill_missing_uids(ds_dict)`. After `to_json_dict` + file_meta merge, it reinserts any of `StudyInstanceUID` (0020000D) / `SeriesInstanceUID` (0020000E) / `SOPInstanceUID` (00080018) that are absent from the dict, using the cached values on the `Instance` (populated earlier by `validate()`).

This restores the property that the JSON-serialized metadata always carries the three identifying UIDs — which matches the expectation of `deid_dicom_header` and every downstream consumer.

### Why use the cached fields

`Instance.validate()` reads the UIDs from the DICOM *before* strict_reading is applied:

```python
with pydicom3.dcmread(f, defer_size=1) as ds:
    self._instance_uid = getattr(ds, "SOPInstanceUID")
    self._series_uid = getattr(ds, "SeriesInstanceUID")
    self._study_uid = getattr(ds, "StudyInstanceUID")
```

So the cached values preserve the non-conformant-but-real UIDs verbatim. The backfill reinserts the same bytes that the P10 originally carried — no fabrication, no lossy canonicalization.

## Verification

**Unit test** — `test_extract_metadata_backfills_invalid_uid` constructs a DICOM with all three UID categories of violations (leading-zero Study, non-digit Series, >64-char SOP), drives it through `Instance.validate()` + `extract_metadata()`, and asserts that all three tags are present in `instance.metadata` with their original bytes.

**Counter-check** — monkey-patched `_backfill_missing_uids` to a no-op and confirmed the test fails with `KeyError: '0020000D'`, proving that the backfill is load-bearing.

**Standalone probe** — isolated reproduction showing `to_json_dict(suppress_invalid_tags=True)` drops each UID flavor after a disk round-trip through `save_as`/`dcmread`. (Not checked in; reproducible via the unit test.)

## Scope

- No changes to public API
- No changes to the existing `extract_metadata` flow for conformant UIDs (backfill is a pure addition — noop when the tag is already present)
- Does **not** backfill new series from scratch: existing ~12.9k NULL series in `public_table` will stay NULL until their COD `metadata.json` is re-extracted. This PR prevents the bleed going forward; any backfill of the existing data is out of scope.

## Test plan

- [x] New unit test passes locally (`test_extract_metadata_backfills_invalid_uid`)
- [x] All other tests in `test_instance.py` still green
- [x] Sanity-checked with backfill removed — new test fails as expected
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)