### PR TITLE
PROC-1502: Bump version to 0.2.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cloud-optimized-dicom"
-version = "0.2.4"
+version = "0.2.5"
 description = "A library for efficiently storing and interacting with DICOM files in the cloud"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
## Summary
- Bump `cloud-optimized-dicom` version from 0.2.4 → 0.2.5 to release the fix from #95 (PROC-1502: Backfill dropped UID tags in `Instance.extract_metadata`).

## Release steps
Once merged, tag `v0.2.5` on main and push the tag to trigger the `publish-to-pypi` workflow.

## Test plan
- [ ] Merge this PR
- [ ] Tag and push `v0.2.5`
- [ ] Verify the PyPI publish workflow succeeds