### PR TITLE
test(PROC-1554): migrate test suite from unittest to pytest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
       run: |
         set -o pipefail
         for attempt in 1 2 3; do
-          python -m unittest discover -v cloud_optimized_dicom.tests 2>&1 | tee test_output.txt && exit 0
+          python -m pytest -v cloud_optimized_dicom/tests 2>&1 | tee test_output.txt && exit 0
           if grep -q "429" test_output.txt; then
             echo "Attempt $attempt failed with 429 rate-limit error, retrying in 30s..."
             sleep 30

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,13 +20,13 @@ pre-commit install
 ### Testing
 ```bash
 # Run all tests
-SISKIN_ENV_ENABLED=1 python -m unittest discover -v cloud_optimized_dicom.tests
+SISKIN_ENV_ENABLED=1 python -m pytest -v cloud_optimized_dicom/tests
 
 # Run specific test file
-SISKIN_ENV_ENABLED=1 python -m unittest cloud_optimized_dicom.tests.test_cod_object -v
+SISKIN_ENV_ENABLED=1 python -m pytest -v cloud_optimized_dicom/tests/test_cod_object.py
 
 # Run specific test
-python -m unittest cloud_optimized_dicom.tests.test_metadata_serialization.TestMetadataSerialization.test_v2_round_trip -v
+python -m pytest -v cloud_optimized_dicom/tests/test_metadata_serialization.py::test_v2_round_trip
 ```
 
 Note: `SISKIN_ENV_ENABLED=1` is required for tests that interact with GCP resources. Tests skip when this flag is absent.

--- a/cloud_optimized_dicom/tests/conftest.py
+++ b/cloud_optimized_dicom/tests/conftest.py
@@ -1,0 +1,53 @@
+import os
+
+import pytest
+from google.api_core.client_options import ClientOptions
+from google.cloud import storage
+
+from cloud_optimized_dicom.utils import delete_uploaded_blobs
+
+GCP_PROJECT = "gradient-pacs-siskin-172863"
+DEFAULT_DATASTORE_PATH = "gs://siskin-172863-temp/cod_tests/dicomweb"
+
+TEST_INSTANCE_UID = "1.2.276.0.50.192168001092.11156604.14547392.313"
+TEST_SERIES_UID = "1.2.276.0.50.192168001092.11156604.14547392.303"
+TEST_STUDY_UID = "1.2.276.0.50.192168001092.11156604.14547392.4"
+
+
+@pytest.fixture(scope="session")
+def test_data_dir() -> str:
+    return os.path.join(os.path.dirname(__file__), "test_data")
+
+
+@pytest.fixture(scope="session")
+def local_instance_path(test_data_dir: str) -> str:
+    return os.path.join(test_data_dir, "monochrome2.dcm")
+
+
+@pytest.fixture(scope="session")
+def gcs_client() -> storage.Client:
+    return storage.Client(
+        project=GCP_PROJECT,
+        client_options=ClientOptions(quota_project_id=GCP_PROJECT),
+    )
+
+
+@pytest.fixture()
+def datastore_path(gcs_client: storage.Client) -> str:
+    delete_uploaded_blobs(gcs_client, [DEFAULT_DATASTORE_PATH])
+    return DEFAULT_DATASTORE_PATH
+
+
+@pytest.fixture(scope="session")
+def test_instance_uid() -> str:
+    return TEST_INSTANCE_UID
+
+
+@pytest.fixture(scope="session")
+def test_series_uid() -> str:
+    return TEST_SERIES_UID
+
+
+@pytest.fixture(scope="session")
+def test_study_uid() -> str:
+    return TEST_STUDY_UID

--- a/cloud_optimized_dicom/tests/test_appender.py
+++ b/cloud_optimized_dicom/tests/test_appender.py
@@ -1,420 +1,478 @@
 import os
-import unittest
 from tempfile import NamedTemporaryFile
 
 import pydicom3
-from google.api_core.client_options import ClientOptions
+import pytest
 from google.cloud import storage
 
 from cloud_optimized_dicom.append import AppendResult, _assert_not_too_large
 from cloud_optimized_dicom.cod_object import CODObject
 from cloud_optimized_dicom.hints import Hints
 from cloud_optimized_dicom.instance import Instance
-from cloud_optimized_dicom.utils import delete_uploaded_blobs
 
 
-class TestAppender(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        cls.test_data_dir = os.path.join(os.path.dirname(__file__), "test_data")
-        cls.test_instance_uid = "1.2.276.0.50.192168001092.11156604.14547392.313"
-        cls.test_series_uid = "1.2.276.0.50.192168001092.11156604.14547392.303"
-        cls.test_study_uid = "1.2.276.0.50.192168001092.11156604.14547392.4"
-        cls.local_instance_path = os.path.join(cls.test_data_dir, "monochrome2.dcm")
-        cls.client = storage.Client(
-            project="gradient-pacs-siskin-172863",
-            client_options=ClientOptions(
-                quota_project_id="gradient-pacs-siskin-172863"
-            ),
-        )
-        cls.datastore_path = "gs://siskin-172863-temp/cod_tests/dicomweb"
-
-    def setUp(self):
-        # before running each test, make sure datastore_path is empty
-        delete_uploaded_blobs(self.client, [self.datastore_path])
-
-    def test_instance_too_large(self):
-        instance = Instance(self.local_instance_path, hints=Hints(size=1000000))
-        self.assertEqual(instance.size(trust_hints_if_available=True), 1000000)
-        cod_object = CODObject(
-            datastore_path=self.datastore_path,
-            client=self.client,
-            study_uid=self.test_study_uid,
-            series_uid=self.test_series_uid,
-            mode="w",
-            sync_on_exit=False,
-        )
-        # test instance of acceptable size is not filtered
-        filtered_instances, append_result = _assert_not_too_large(
+def test_instance_too_large(
+    gcs_client: storage.Client,
+    datastore_path: str,
+    local_instance_path: str,
+    test_study_uid: str,
+    test_series_uid: str,
+):
+    instance = Instance(local_instance_path, hints=Hints(size=1000000))
+    assert instance.size(trust_hints_if_available=True) == 1000000
+    cod_object = CODObject(
+        datastore_path=datastore_path,
+        client=gcs_client,
+        study_uid=test_study_uid,
+        series_uid=test_series_uid,
+        mode="w",
+        sync_on_exit=False,
+    )
+    # test instance of acceptable size is not filtered
+    filtered_instances, append_result = _assert_not_too_large(
+        cod_object=cod_object,
+        instances=[instance],
+        max_instance_size=1,
+        max_series_size=100,
+        append_result=AppendResult(),
+    )
+    assert len(filtered_instances) == 1
+    assert len(append_result.errors) == 0
+    # test instance of unacceptable size is filtered
+    filtered_instances, append_result = _assert_not_too_large(
+        cod_object=cod_object,
+        instances=[instance],
+        max_instance_size=0.0001,
+        max_series_size=100,
+        append_result=AppendResult(),
+    )
+    assert len(filtered_instances) == 0
+    assert len(append_result.errors) == 1
+    # test series being too large raises an error
+    with pytest.raises(ValueError):
+        _assert_not_too_large(
             cod_object=cod_object,
             instances=[instance],
             max_instance_size=1,
-            max_series_size=100,
+            max_series_size=0.0001,
             append_result=AppendResult(),
         )
-        self.assertEqual(len(filtered_instances), 1)
-        self.assertEqual(len(append_result.errors), 0)
-        # test instance of unacceptable size is filtered
-        filtered_instances, append_result = _assert_not_too_large(
-            cod_object=cod_object,
-            instances=[instance],
-            max_instance_size=0.0001,
-            max_series_size=100,
-            append_result=AppendResult(),
-        )
-        self.assertEqual(len(filtered_instances), 0)
-        self.assertEqual(len(append_result.errors), 1)
-        # test series being too large raises an error
-        with self.assertRaises(ValueError):
-            _assert_not_too_large(
-                cod_object=cod_object,
-                instances=[instance],
-                max_instance_size=1,
-                max_series_size=0.0001,
-                append_result=AppendResult(),
-            )
 
-    def test_append(self):
-        cod_obj = CODObject(
-            client=self.client,
-            datastore_path=self.datastore_path,
-            study_uid=self.test_study_uid,
-            series_uid=self.test_series_uid,
-            mode="w",
-            sync_on_exit=False,
-        )
-        instance = Instance(dicom_uri=self.local_instance_path)
-        new, same, conflict, errors = cod_obj.append([instance])
-        self.assertEqual(len(new), 1)
-        self.assertEqual(len(same + conflict + errors), 0)
 
-    def test_two_part_append(self):
-        instance_a = Instance(
-            os.path.join(
-                self.test_data_dir,
-                "series",
-                "1.2.826.0.1.3680043.8.498.22997958494980951977704130269567444795.dcm",
-            )
+def test_append(
+    gcs_client: storage.Client,
+    datastore_path: str,
+    local_instance_path: str,
+    test_study_uid: str,
+    test_series_uid: str,
+):
+    cod_obj = CODObject(
+        client=gcs_client,
+        datastore_path=datastore_path,
+        study_uid=test_study_uid,
+        series_uid=test_series_uid,
+        mode="w",
+        sync_on_exit=False,
+    )
+    instance = Instance(dicom_uri=local_instance_path)
+    new, same, conflict, errors = cod_obj.append([instance])
+    assert len(new) == 1
+    assert len(same + conflict + errors) == 0
+
+
+def test_two_part_append(
+    gcs_client: storage.Client, datastore_path: str, test_data_dir: str
+):
+    instance_a = Instance(
+        os.path.join(
+            test_data_dir,
+            "series",
+            "1.2.826.0.1.3680043.8.498.22997958494980951977704130269567444795.dcm",
         )
-        instance_b = Instance(
-            os.path.join(
-                self.test_data_dir,
-                "series",
-                "1.2.826.0.1.3680043.8.498.28109707839310833322020505651875585013.dcm",
-            )
+    )
+    instance_b = Instance(
+        os.path.join(
+            test_data_dir,
+            "series",
+            "1.2.826.0.1.3680043.8.498.28109707839310833322020505651875585013.dcm",
         )
-        cod_obj = CODObject(
-            client=self.client,
-            datastore_path=self.datastore_path,
-            study_uid=instance_a.study_uid(),
-            series_uid=instance_a.series_uid(),
-            mode="w",
-            sync_on_exit=False,
+    )
+    cod_obj = CODObject(
+        client=gcs_client,
+        datastore_path=datastore_path,
+        study_uid=instance_a.study_uid(),
+        series_uid=instance_a.series_uid(),
+        mode="w",
+        sync_on_exit=False,
+    )
+    new, same, conflict, errors = cod_obj.append([instance_a])
+    assert len(new) == 1
+    assert len(same + conflict + errors) == 0
+    cod_obj = CODObject(
+        client=gcs_client,
+        datastore_path=datastore_path,
+        study_uid=instance_a.study_uid(),
+        series_uid=instance_a.series_uid(),
+        mode="w",
+        sync_on_exit=False,
+    )
+    new, same, conflict, errors = cod_obj.append([instance_b])
+    assert len(new) == 1
+    assert len(same + conflict + errors) == 0
+
+
+def test_append_true_dupe(
+    gcs_client: storage.Client,
+    datastore_path: str,
+    local_instance_path: str,
+    test_study_uid: str,
+    test_series_uid: str,
+):
+    cod_obj = CODObject(
+        client=gcs_client,
+        datastore_path=datastore_path,
+        study_uid=test_study_uid,
+        series_uid=test_series_uid,
+        mode="w",
+        sync_on_exit=False,
+    )
+    # start by appending instance normally
+    instance = Instance(dicom_uri=local_instance_path)
+    new, same, conflict, errors = cod_obj.append([instance])
+    assert len(new) == 1
+    assert len(same + conflict + errors) == 0
+    # now append the same instance again, which should be a duplicate
+    new, same, conflict, errors = cod_obj.append([instance])
+    assert len(same) == 1
+    assert len(conflict + new + errors) == 0
+
+
+def test_append_diff_hash_dupe(
+    gcs_client: storage.Client,
+    datastore_path: str,
+    local_instance_path: str,
+    test_study_uid: str,
+    test_series_uid: str,
+):
+    cod_obj = CODObject(
+        client=gcs_client,
+        datastore_path=datastore_path,
+        study_uid=test_study_uid,
+        series_uid=test_series_uid,
+        mode="w",
+        sync_on_exit=False,
+    )
+    # start by appending instance normally
+    instance = Instance(dicom_uri=local_instance_path)
+    new, same, conflict, errors = cod_obj.append([instance])
+    assert len(new) == 1
+    assert len(same + conflict + errors) == 0
+    assert len(cod_obj._metadata.instances) == 1
+    assert (
+        cod_obj._metadata.instances[instance.instance_uid()].crc32c()
+        == instance.crc32c()
+    )
+    # make a diff hash dupe
+    with NamedTemporaryFile(suffix=".dcm") as f:
+        with pydicom3.dcmread(local_instance_path) as ds:
+            ds.add_new((0x1234, 0x5678), "DS", "12345678")
+            ds.save_as(f.name)
+        assert os.path.exists(f.name)
+        diff_hash_dupe = Instance(dicom_uri=f.name)
+        assert diff_hash_dupe.crc32c() != instance.crc32c()
+        new, same, conflict, errors = cod_obj.append([diff_hash_dupe])
+        assert len(conflict) == 1
+        assert len(same + new + errors) == 0
+
+
+def test_append_and_sync(
+    gcs_client: storage.Client,
+    datastore_path: str,
+    local_instance_path: str,
+    test_study_uid: str,
+    test_series_uid: str,
+):
+    cod_obj = CODObject(
+        client=gcs_client,
+        datastore_path=datastore_path,
+        study_uid=test_study_uid,
+        series_uid=test_series_uid,
+        mode="w",
+    )
+    instance = Instance(dicom_uri=local_instance_path)
+    new, same, conflict, errors = cod_obj.append([instance])
+    assert len(new) == 1
+    assert len(same + conflict + errors) == 0
+    assert not cod_obj._tar_synced
+    assert not cod_obj._metadata_synced
+    tar_blob = storage.Blob.from_string(cod_obj.tar_uri, client=gcs_client)
+    assert not tar_blob.exists()
+    index_blob = storage.Blob.from_string(cod_obj.index_uri, client=gcs_client)
+    assert not index_blob.exists()
+    metadata_blob = storage.Blob.from_string(cod_obj.metadata_uri, client=gcs_client)
+    assert not metadata_blob.exists()
+    cod_obj._sync()
+    assert cod_obj._tar_synced
+    assert cod_obj._metadata_synced
+    assert tar_blob.exists()
+    assert index_blob.exists()
+    assert metadata_blob.exists()
+
+
+def test_append_and_sync_two_part(
+    gcs_client: storage.Client, datastore_path: str, test_data_dir: str
+):
+    instance_a = Instance(
+        os.path.join(
+            test_data_dir,
+            "series",
+            "1.2.826.0.1.3680043.8.498.22997958494980951977704130269567444795.dcm",
         )
+    )
+    instance_b = Instance(
+        os.path.join(
+            test_data_dir,
+            "series",
+            "1.2.826.0.1.3680043.8.498.28109707839310833322020505651875585013.dcm",
+        )
+    )
+    with CODObject(
+        client=gcs_client,
+        datastore_path=datastore_path,
+        study_uid=instance_a.study_uid(),
+        series_uid=instance_a.series_uid(),
+        mode="w",
+    ) as cod_obj:
         new, same, conflict, errors = cod_obj.append([instance_a])
-        self.assertEqual(len(new), 1)
-        self.assertEqual(len(same + conflict + errors), 0)
-        cod_obj = CODObject(
-            client=self.client,
-            datastore_path=self.datastore_path,
-            study_uid=instance_a.study_uid(),
-            series_uid=instance_a.series_uid(),
-            mode="w",
-            sync_on_exit=False,
-        )
+        assert len(new) == 1
+        assert len(same + conflict + errors) == 0
+        # sync happens automatically on context exit
+    with CODObject(
+        client=gcs_client,
+        datastore_path=datastore_path,
+        study_uid=instance_a.study_uid(),
+        series_uid=instance_a.series_uid(),
+        mode="w",
+        sync_on_exit=False,
+    ) as cod_obj:
         new, same, conflict, errors = cod_obj.append([instance_b])
-        self.assertEqual(len(new), 1)
-        self.assertEqual(len(same + conflict + errors), 0)
+        assert len(new) == 1
+        assert len(same + conflict + errors) == 0
 
-    def test_append_true_dupe(self):
-        cod_obj = CODObject(
-            client=self.client,
-            datastore_path=self.datastore_path,
-            study_uid=self.test_study_uid,
-            series_uid=self.test_series_uid,
-            mode="w",
-            sync_on_exit=False,
-        )
-        # start by appending instance normally
-        instance = Instance(dicom_uri=self.local_instance_path)
-        new, same, conflict, errors = cod_obj.append([instance])
-        self.assertEqual(len(new), 1)
-        self.assertEqual(len(same + conflict + errors), 0)
-        # now append the same instance again, which should be a duplicate
-        new, same, conflict, errors = cod_obj.append([instance])
-        self.assertEqual(len(same), 1)
-        self.assertEqual(len(conflict + new + errors), 0)
 
-    def test_append_diff_hash_dupe(self):
-        cod_obj = CODObject(
-            client=self.client,
-            datastore_path=self.datastore_path,
-            study_uid=self.test_study_uid,
-            series_uid=self.test_series_uid,
-            mode="w",
-            sync_on_exit=False,
-        )
-        # start by appending instance normally
-        instance = Instance(dicom_uri=self.local_instance_path)
-        new, same, conflict, errors = cod_obj.append([instance])
-        self.assertEqual(len(new), 1)
-        self.assertEqual(len(same + conflict + errors), 0)
-        self.assertEqual(len(cod_obj._metadata.instances), 1)
-        self.assertEqual(
-            cod_obj._metadata.instances[instance.instance_uid()].crc32c(),
-            instance.crc32c(),
-        )
-        # make a diff hash dupe
-        with NamedTemporaryFile(suffix=".dcm") as f:
-            with pydicom3.dcmread(self.local_instance_path) as ds:
-                ds.add_new((0x1234, 0x5678), "DS", "12345678")
-                ds.save_as(f.name)
-            self.assertTrue(os.path.exists(f.name))
-            diff_hash_dupe = Instance(dicom_uri=f.name)
-            self.assertNotEqual(diff_hash_dupe.crc32c(), instance.crc32c())
-            new, same, conflict, errors = cod_obj.append([diff_hash_dupe])
-            self.assertEqual(len(conflict), 1)
-            self.assertEqual(len(same + new + errors), 0)
+def test_append_wrong_series(
+    gcs_client: storage.Client, datastore_path: str, local_instance_path: str
+):
+    """Expect instance from different series than CODObject to error"""
+    cod_obj = CODObject(
+        client=gcs_client,
+        datastore_path=datastore_path,
+        study_uid="some_other_study_uid",
+        series_uid="some_other_series_uid",
+        mode="w",
+        sync_on_exit=False,
+    )
+    bad_instance = Instance(dicom_uri=local_instance_path)
+    new, same, conflict, errors = cod_obj.append([bad_instance])
+    assert len(errors) == 1
+    assert len(new + same + conflict) == 0
+    assert "does not belong to COD object" in str(errors[0][1])
 
-    def test_append_and_sync(self):
-        cod_obj = CODObject(
-            client=self.client,
-            datastore_path=self.datastore_path,
-            study_uid=self.test_study_uid,
-            series_uid=self.test_series_uid,
-            mode="w",
-        )
-        instance = Instance(dicom_uri=self.local_instance_path)
-        new, same, conflict, errors = cod_obj.append([instance])
-        self.assertEqual(len(new), 1)
-        self.assertEqual(len(same + conflict + errors), 0)
-        self.assertFalse(cod_obj._tar_synced)
-        self.assertFalse(cod_obj._metadata_synced)
-        tar_blob = storage.Blob.from_string(cod_obj.tar_uri, client=self.client)
-        self.assertFalse(tar_blob.exists())
-        index_blob = storage.Blob.from_string(cod_obj.index_uri, client=self.client)
-        self.assertFalse(index_blob.exists())
-        metadata_blob = storage.Blob.from_string(
-            cod_obj.metadata_uri, client=self.client
-        )
-        self.assertFalse(metadata_blob.exists())
-        cod_obj._sync()
-        self.assertTrue(cod_obj._tar_synced)
-        self.assertTrue(cod_obj._metadata_synced)
-        self.assertTrue(tar_blob.exists())
-        self.assertTrue(index_blob.exists())
-        self.assertTrue(metadata_blob.exists())
 
-    def test_append_and_sync_two_part(self):
-        instance_a = Instance(
-            os.path.join(
-                self.test_data_dir,
-                "series",
-                "1.2.826.0.1.3680043.8.498.22997958494980951977704130269567444795.dcm",
+def test_append_bad_hint(
+    gcs_client: storage.Client,
+    datastore_path: str,
+    local_instance_path: str,
+    test_study_uid: str,
+    test_series_uid: str,
+):
+    """Expect instance with bad hint to error"""
+    cod_obj = CODObject(
+        client=gcs_client,
+        datastore_path=datastore_path,
+        study_uid=test_study_uid,
+        series_uid=test_series_uid,
+        mode="w",
+        sync_on_exit=False,
+    )
+    bad_instance = Instance(
+        dicom_uri=local_instance_path,
+        hints=Hints(study_uid="bad_study_uid"),
+    )
+    new, same, conflict, errors = cod_obj.append([bad_instance])
+    assert len(errors) == 1
+    assert len(new + same + conflict) == 0
+    assert "Hint mismatch for field study_uid" in str(errors[0][1])
+
+
+def test_append_bad_uri_remote(
+    gcs_client: storage.Client,
+    datastore_path: str,
+    test_study_uid: str,
+    test_series_uid: str,
+):
+    """test nonexistent remote URI handling"""
+    cod_obj = CODObject(
+        client=gcs_client,
+        datastore_path=datastore_path,
+        study_uid=test_study_uid,
+        series_uid=test_series_uid,
+        mode="w",
+        sync_on_exit=False,
+    )
+    instance = Instance(dicom_uri="gs://some-hospital/that/does/not/exist.dcm")
+    new, same, conflict, errors = cod_obj.append([instance])
+    assert len(errors) == 1
+    assert len(new + same + conflict) == 0
+    assert "not found" in str(errors[0][1])
+
+
+def test_append_bad_uri_local(
+    gcs_client: storage.Client,
+    datastore_path: str,
+    test_study_uid: str,
+    test_series_uid: str,
+):
+    """test nonexistent local URI handling"""
+    cod_obj = CODObject(
+        client=gcs_client,
+        datastore_path=datastore_path,
+        study_uid=test_study_uid,
+        series_uid=test_series_uid,
+        mode="w",
+        sync_on_exit=False,
+    )
+    instance = Instance(dicom_uri="/some/local/path/that/does/not/exist.dcm")
+    new, same, conflict, errors = cod_obj.append([instance])
+    assert len(errors) == 1
+    assert len(new + same + conflict) == 0
+    assert "No such file or directory" in str(errors[0][1])
+
+
+def test_append_mix(
+    gcs_client: storage.Client,
+    datastore_path: str,
+    local_instance_path: str,
+    test_study_uid: str,
+    test_series_uid: str,
+):
+    """test mix of good and bad URIs"""
+    cod_obj = CODObject(
+        client=gcs_client,
+        datastore_path=datastore_path,
+        study_uid=test_study_uid,
+        series_uid=test_series_uid,
+        mode="w",
+        sync_on_exit=False,
+    )
+    good_instance = Instance(dicom_uri=local_instance_path)
+    bad_instance = Instance(dicom_uri="gs://some-hospital/that/does/not/exist.dcm")
+    new, same, conflict, errors = cod_obj.append([good_instance, bad_instance])
+    assert len(errors) == 1
+    assert len(new + same + conflict) == 1
+
+
+def test_append_corrupt_dicom(
+    gcs_client: storage.Client,
+    datastore_path: str,
+    local_instance_path: str,
+):
+    """test that corrupt dicom is not appended"""
+    good_instance = Instance(dicom_uri=local_instance_path)
+
+    # create a corrupt dicom (has proper header but then is garbage)
+    with NamedTemporaryFile(suffix=".dcm") as f:
+        with pydicom3.FileDataset(
+            f.name, {}, is_little_endian=True, is_implicit_VR=False
+        ) as ds:
+            ds.StudyInstanceUID = (
+                "1.2.826.0.1.3680043.8.498.75141544885342931881503164869995724634"
             )
-        )
-        instance_b = Instance(
-            os.path.join(
-                self.test_data_dir,
-                "series",
-                "1.2.826.0.1.3680043.8.498.28109707839310833322020505651875585013.dcm",
+            ds.SeriesInstanceUID = (
+                "1.2.826.0.1.3680043.8.498.34266834008938638668629534063784433302"
             )
-        )
-        with CODObject(
-            client=self.client,
-            datastore_path=self.datastore_path,
-            study_uid=instance_a.study_uid(),
-            series_uid=instance_a.series_uid(),
-            mode="w",
-        ) as cod_obj:
-            new, same, conflict, errors = cod_obj.append([instance_a])
-            self.assertEqual(len(new), 1)
-            self.assertEqual(len(same + conflict + errors), 0)
-            # sync happens automatically on context exit
-        with CODObject(
-            client=self.client,
-            datastore_path=self.datastore_path,
-            study_uid=instance_a.study_uid(),
-            series_uid=instance_a.series_uid(),
-            mode="w",
-            sync_on_exit=False,
-        ) as cod_obj:
-            new, same, conflict, errors = cod_obj.append([instance_b])
-            self.assertEqual(len(new), 1)
-            self.assertEqual(len(same + conflict + errors), 0)
+            ds.SOPInstanceUID = "1.2.3.4.5.6.7.8.9.0"
+            ds.save_as(f.name)
 
-    def test_append_wrong_series(self):
-        """Expect instance from different series than CODObject to error"""
-        cod_obj = CODObject(
-            client=self.client,
-            datastore_path=self.datastore_path,
-            study_uid="some_other_study_uid",
-            series_uid="some_other_series_uid",
-            mode="w",
-            sync_on_exit=False,
-        )
-        bad_instance = Instance(dicom_uri=self.local_instance_path)
-        new, same, conflict, errors = cod_obj.append([bad_instance])
-        self.assertEqual(len(errors), 1)
-        self.assertEqual(len(new + same + conflict), 0)
-        self.assertIn("does not belong to COD object", str(errors[0][1]))
-
-    def test_append_bad_hint(self):
-        """Expect instance with bad hint to error"""
-        cod_obj = CODObject(
-            client=self.client,
-            datastore_path=self.datastore_path,
-            study_uid=self.test_study_uid,
-            series_uid=self.test_series_uid,
-            mode="w",
-            sync_on_exit=False,
-        )
         bad_instance = Instance(
-            dicom_uri=self.local_instance_path,
-            hints=Hints(study_uid="bad_study_uid"),
-        )
-        new, same, conflict, errors = cod_obj.append([bad_instance])
-        self.assertEqual(len(errors), 1)
-        self.assertEqual(len(new + same + conflict), 0)
-        self.assertIn("Hint mismatch for field study_uid", str(errors[0][1]))
-
-    def test_append_bad_uri_remote(self):
-        """test nonexistent remote URI handling"""
-        cod_obj = CODObject(
-            client=self.client,
-            datastore_path=self.datastore_path,
-            study_uid=self.test_study_uid,
-            series_uid=self.test_series_uid,
-            mode="w",
-            sync_on_exit=False,
-        )
-        instance = Instance(dicom_uri="gs://some-hospital/that/does/not/exist.dcm")
-        new, same, conflict, errors = cod_obj.append([instance])
-        self.assertEqual(len(errors), 1)
-        self.assertEqual(len(new + same + conflict), 0)
-        self.assertIn("not found", str(errors[0][1]))
-
-    def test_append_bad_uri_local(self):
-        """test nonexistent local URI handling"""
-        cod_obj = CODObject(
-            client=self.client,
-            datastore_path=self.datastore_path,
-            study_uid=self.test_study_uid,
-            series_uid=self.test_series_uid,
-            mode="w",
-            sync_on_exit=False,
-        )
-        instance = Instance(dicom_uri="/some/local/path/that/does/not/exist.dcm")
-        new, same, conflict, errors = cod_obj.append([instance])
-        self.assertEqual(len(errors), 1)
-        self.assertEqual(len(new + same + conflict), 0)
-        self.assertIn("No such file or directory", str(errors[0][1]))
-
-    def test_append_mix(self):
-        """test mix of good and bad URIs"""
-        cod_obj = CODObject(
-            client=self.client,
-            datastore_path=self.datastore_path,
-            study_uid=self.test_study_uid,
-            series_uid=self.test_series_uid,
-            mode="w",
-            sync_on_exit=False,
-        )
-        good_instance = Instance(dicom_uri=self.local_instance_path)
-        bad_instance = Instance(dicom_uri="gs://some-hospital/that/does/not/exist.dcm")
-        new, same, conflict, errors = cod_obj.append([good_instance, bad_instance])
-        self.assertEqual(len(errors), 1)
-        self.assertEqual(len(new + same + conflict), 1)
-
-    def test_append_corrupt_dicom(self):
-        """test that corrupt dicom is not appended"""
-        good_instance = Instance(dicom_uri=self.local_instance_path)
-
-        # create a corrupt dicom (has proper header but then is garbage)
-        with NamedTemporaryFile(suffix=".dcm") as f:
-            with pydicom3.FileDataset(
-                f.name, {}, is_little_endian=True, is_implicit_VR=False
-            ) as ds:
-                ds.StudyInstanceUID = (
-                    "1.2.826.0.1.3680043.8.498.75141544885342931881503164869995724634"
-                )
-                ds.SeriesInstanceUID = (
-                    "1.2.826.0.1.3680043.8.498.34266834008938638668629534063784433302"
-                )
-                ds.SOPInstanceUID = "1.2.3.4.5.6.7.8.9.0"
-                ds.save_as(f.name)
-
-            bad_instance = Instance(
-                dicom_uri=f.name,
-                hints=Hints(
-                    size=os.path.getsize(f.name),
-                    crc32c="some_crc32c",
-                    instance_uid="some_instance_uid",
-                    study_uid=good_instance.study_uid(),
-                    series_uid=good_instance.series_uid(),
-                ),
-            )
-            with CODObject(
-                datastore_path=self.datastore_path,
-                client=self.client,
+            dicom_uri=f.name,
+            hints=Hints(
+                size=os.path.getsize(f.name),
+                crc32c="some_crc32c",
+                instance_uid="some_instance_uid",
                 study_uid=good_instance.study_uid(),
                 series_uid=good_instance.series_uid(),
-                mode="w",
-                sync_on_exit=False,
-            ) as cod_obj:
-                new, same, conflict, errors = cod_obj.append(
-                    [bad_instance, good_instance]
-                )
-                self.assertEqual(len(new), 1)
-                self.assertEqual(len(same + conflict), 0)
-                self.assertEqual(len(errors), 1)
-                self.assertEqual(errors[0][0], bad_instance)
-
-    def test_append_dupe_uri_input(self):
-        """test duplicate URI handling"""
-        cod_obj = CODObject(
-            client=self.client,
-            datastore_path=self.datastore_path,
-            study_uid=self.test_study_uid,
-            series_uid=self.test_series_uid,
-            mode="w",
-            sync_on_exit=False,
-        )
-        instance = Instance(dicom_uri=self.local_instance_path)
-        instance_v2 = Instance(
-            dicom_uri=self.local_instance_path,
-            hints=Hints(
-                instance_uid=instance.instance_uid(),
-                crc32c="some_other_hash",
-                size=instance.size() + 1,
             ),
         )
-        new, same, conflict, errors = cod_obj.append([instance_v2, instance])
-
-    def test_append_compress(self):
-        """test that compressing instances works"""
-        cod_obj = CODObject(
-            client=self.client,
-            datastore_path=self.datastore_path,
-            study_uid=self.test_study_uid,
-            series_uid=self.test_series_uid,
+        with CODObject(
+            datastore_path=datastore_path,
+            client=gcs_client,
+            study_uid=good_instance.study_uid(),
+            series_uid=good_instance.series_uid(),
             mode="w",
             sync_on_exit=False,
-        )
-        instance = Instance(dicom_uri=self.local_instance_path)
-        with instance.open() as f:
-            ds = pydicom3.dcmread(f)
-            self.assertEqual(
-                ds.file_meta.TransferSyntaxUID, pydicom3.uid.ImplicitVRLittleEndian
-            )
-        uncompressed_size = instance.size()
-        new, same, conflict, errors = cod_obj.append([instance], compress=True)
-        self.assertEqual(len(new), 1)
-        self.assertEqual(len(same + conflict + errors), 0)
-        self.assertLess(instance.size(), uncompressed_size)
-        with instance.open() as f:
-            ds = pydicom3.dcmread(f)
-            self.assertEqual(
-                ds.file_meta.TransferSyntaxUID, pydicom3.uid.JPEG2000Lossless
-            )
-        self.assertLess(instance.size(), uncompressed_size)
+        ) as cod_obj:
+            new, same, conflict, errors = cod_obj.append([bad_instance, good_instance])
+            assert len(new) == 1
+            assert len(same + conflict) == 0
+            assert len(errors) == 1
+            assert errors[0][0] == bad_instance
+
+
+def test_append_dupe_uri_input(
+    gcs_client: storage.Client,
+    datastore_path: str,
+    local_instance_path: str,
+    test_study_uid: str,
+    test_series_uid: str,
+):
+    """test duplicate URI handling"""
+    cod_obj = CODObject(
+        client=gcs_client,
+        datastore_path=datastore_path,
+        study_uid=test_study_uid,
+        series_uid=test_series_uid,
+        mode="w",
+        sync_on_exit=False,
+    )
+    instance = Instance(dicom_uri=local_instance_path)
+    instance_v2 = Instance(
+        dicom_uri=local_instance_path,
+        hints=Hints(
+            instance_uid=instance.instance_uid(),
+            crc32c="some_other_hash",
+            size=instance.size() + 1,
+        ),
+    )
+    cod_obj.append([instance_v2, instance])
+
+
+def test_append_compress(
+    gcs_client: storage.Client,
+    datastore_path: str,
+    local_instance_path: str,
+    test_study_uid: str,
+    test_series_uid: str,
+):
+    """test that compressing instances works"""
+    cod_obj = CODObject(
+        client=gcs_client,
+        datastore_path=datastore_path,
+        study_uid=test_study_uid,
+        series_uid=test_series_uid,
+        mode="w",
+        sync_on_exit=False,
+    )
+    instance = Instance(dicom_uri=local_instance_path)
+    with instance.open() as f:
+        ds = pydicom3.dcmread(f)
+        assert ds.file_meta.TransferSyntaxUID == pydicom3.uid.ImplicitVRLittleEndian
+    uncompressed_size = instance.size()
+    new, same, conflict, errors = cod_obj.append([instance], compress=True)
+    assert len(new) == 1
+    assert len(same + conflict + errors) == 0
+    assert instance.size() < uncompressed_size
+    with instance.open() as f:
+        ds = pydicom3.dcmread(f)
+        assert ds.file_meta.TransferSyntaxUID == pydicom3.uid.JPEG2000Lossless
+    assert instance.size() < uncompressed_size

--- a/cloud_optimized_dicom/tests/test_cod_object.py
+++ b/cloud_optimized_dicom/tests/test_cod_object.py
@@ -1,155 +1,155 @@
-import os
-import unittest
-
-from google.api_core.client_options import ClientOptions
+import pytest
 from google.cloud import storage
 from pydicom3 import dcmread
 
 from cloud_optimized_dicom.cod_object import CODObject
 from cloud_optimized_dicom.instance import Instance
-from cloud_optimized_dicom.utils import delete_uploaded_blobs, is_remote
+from cloud_optimized_dicom.utils import is_remote
 
 
-class TestCODObject(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        cls.test_data_dir = os.path.join(os.path.dirname(__file__), "test_data")
-        cls.test_instance_uid = "1.2.276.0.50.192168001092.11156604.14547392.313"
-        cls.test_series_uid = "1.2.276.0.50.192168001092.11156604.14547392.303"
-        cls.test_study_uid = "1.2.276.0.50.192168001092.11156604.14547392.4"
-        cls.local_instance_path = os.path.join(cls.test_data_dir, "monochrome2.dcm")
-        cls.client = storage.Client(
-            project="gradient-pacs-siskin-172863",
-            client_options=ClientOptions(
-                quota_project_id="gradient-pacs-siskin-172863"
-            ),
-        )
-        cls.datastore_path = "gs://siskin-172863-temp/cod_tests/dicomweb"
+def test_properties(gcs_client: storage.Client, datastore_path: str):
+    """Test tar_uri, metadata_uri, index_uri, and __str__"""
+    cod_object = CODObject(
+        datastore_path=datastore_path,
+        client=gcs_client,
+        study_uid="1.2.3.4.5.6.7.8.9.0",
+        series_uid="1.2.3.4.5.6.7.8.9.0",
+        mode="r",
+    )
+    assert cod_object.datastore_path == datastore_path
+    assert (
+        cod_object.tar_uri
+        == f"{datastore_path}/studies/1.2.3.4.5.6.7.8.9.0/series/1.2.3.4.5.6.7.8.9.0.tar"
+    )
+    assert (
+        cod_object.metadata_uri
+        == f"{datastore_path}/studies/1.2.3.4.5.6.7.8.9.0/series/1.2.3.4.5.6.7.8.9.0/metadata.json"
+    )
+    assert (
+        cod_object.index_uri
+        == f"{datastore_path}/studies/1.2.3.4.5.6.7.8.9.0/series/1.2.3.4.5.6.7.8.9.0/index.sqlite"
+    )
+    assert (
+        str(cod_object)
+        == f"CODObject({datastore_path}/studies/1.2.3.4.5.6.7.8.9.0/series/1.2.3.4.5.6.7.8.9.0)"
+    )
 
-    def test_properties(self):
-        """Test tar_uri, metadata_uri, index_uri, and __str__"""
-        cod_object = CODObject(
-            datastore_path=self.datastore_path,
-            client=self.client,
-            study_uid="1.2.3.4.5.6.7.8.9.0",
-            series_uid="1.2.3.4.5.6.7.8.9.0",
+
+def test_validate_uids(gcs_client: storage.Client, datastore_path: str):
+    """Test that COD instantiation fails if UIDs are not valid"""
+    with pytest.raises(AssertionError):
+        CODObject(
+            datastore_path=datastore_path,
+            client=gcs_client,
+            study_uid="1.2.3.4.5",
+            series_uid="1.2.3.4.5",
             mode="r",
         )
-        self.assertEqual(cod_object.datastore_path, self.datastore_path)
-        self.assertEqual(
-            cod_object.tar_uri,
-            f"{self.datastore_path}/studies/1.2.3.4.5.6.7.8.9.0/series/1.2.3.4.5.6.7.8.9.0.tar",
-        )
-        self.assertEqual(
-            cod_object.metadata_uri,
-            f"{self.datastore_path}/studies/1.2.3.4.5.6.7.8.9.0/series/1.2.3.4.5.6.7.8.9.0/metadata.json",
-        )
-        self.assertEqual(
-            cod_object.index_uri,
-            f"{self.datastore_path}/studies/1.2.3.4.5.6.7.8.9.0/series/1.2.3.4.5.6.7.8.9.0/index.sqlite",
-        )
-        self.assertEqual(
-            str(cod_object),
-            f"CODObject({self.datastore_path}/studies/1.2.3.4.5.6.7.8.9.0/series/1.2.3.4.5.6.7.8.9.0)",
-        )
 
-    def test_validate_uids(self):
-        """Test that COD instantiation fails if UIDs are not valid"""
-        with self.assertRaises(AssertionError):
-            CODObject(
-                datastore_path=self.datastore_path,
-                client=self.client,
-                study_uid="1.2.3.4.5",
-                series_uid="1.2.3.4.5",
-                mode="r",
-            )
 
-    def test_pull_tar(self):
-        """Test that pull_tar fetches the tar and index and updates the instance dicom_uri"""
-        delete_uploaded_blobs(self.client, [self.datastore_path])
-        # append and sync an instance
-        instance = Instance(dicom_uri=self.local_instance_path)
-        with CODObject(
-            datastore_path=self.datastore_path,
-            client=self.client,
-            study_uid=self.test_study_uid,
-            series_uid=self.test_series_uid,
-            mode="w",
-        ) as cod_obj:
-            cod_obj.append([instance])
-            # sync happens automatically on context exit
-        cod_obj = CODObject(
-            datastore_path=self.datastore_path,
-            client=self.client,
-            study_uid=self.test_study_uid,
-            series_uid=self.test_series_uid,
-            mode="r",
-        )
-        instance = cod_obj.get_metadata().instances[self.test_instance_uid]
-        # Before we pull the tar, the instance should have a remote URI (it exists in the COD datastore)
-        self.assertTrue(is_remote(instance.dicom_uri))
-        cod_obj.pull_tar()
-        # After we pull the tar, the instance should have a local URI (it exists in the local tar file)
-        self.assertEqual(
-            instance.dicom_uri,
-            f"{cod_obj.tar_file_path}://instances/{self.test_instance_uid}.dcm",
-        )
-        # We should be able to open/read the instance in this state from this local tar file
+def test_pull_tar(
+    gcs_client: storage.Client,
+    datastore_path: str,
+    local_instance_path: str,
+    test_study_uid: str,
+    test_series_uid: str,
+    test_instance_uid: str,
+):
+    """Test that pull_tar fetches the tar and index and updates the instance dicom_uri"""
+    # append and sync an instance
+    instance = Instance(dicom_uri=local_instance_path)
+    with CODObject(
+        datastore_path=datastore_path,
+        client=gcs_client,
+        study_uid=test_study_uid,
+        series_uid=test_series_uid,
+        mode="w",
+    ) as cod_obj:
+        cod_obj.append([instance])
+        # sync happens automatically on context exit
+    cod_obj = CODObject(
+        datastore_path=datastore_path,
+        client=gcs_client,
+        study_uid=test_study_uid,
+        series_uid=test_series_uid,
+        mode="r",
+    )
+    instance = cod_obj.get_metadata().instances[test_instance_uid]
+    # Before we pull the tar, the instance should have a remote URI (it exists in the COD datastore)
+    assert is_remote(instance.dicom_uri)
+    cod_obj.pull_tar()
+    # After we pull the tar, the instance should have a local URI (it exists in the local tar file)
+    assert (
+        instance.dicom_uri
+        == f"{cod_obj.tar_file_path}://instances/{test_instance_uid}.dcm"
+    )
+    # We should be able to open/read the instance in this state from this local tar file
+    with instance.open() as f:
+        ds = dcmread(f)
+        assert ds.StudyInstanceUID == test_study_uid
+        assert ds.SeriesInstanceUID == test_series_uid
+        assert ds.SOPInstanceUID == test_instance_uid
+
+
+def test_extract_locally(
+    gcs_client: storage.Client,
+    datastore_path: str,
+    local_instance_path: str,
+    test_study_uid: str,
+    test_series_uid: str,
+    test_instance_uid: str,
+):
+    """Test that extract_locally extracts the tar and index to the local temp dir, and sets the dicom_uri of each instance to the local path"""
+    # append and sync an instance
+    instance = Instance(dicom_uri=local_instance_path)
+    with CODObject(
+        datastore_path=datastore_path,
+        client=gcs_client,
+        study_uid=test_study_uid,
+        series_uid=test_series_uid,
+        mode="w",
+    ) as cod_obj:
+        cod_obj.append([instance])
+        # sync happens automatically on context exit
+    cod_obj = CODObject(
+        datastore_path=datastore_path,
+        client=gcs_client,
+        study_uid=test_study_uid,
+        series_uid=test_series_uid,
+        mode="r",
+    )
+    instance = cod_obj.get_metadata().instances[test_instance_uid]
+    # Before we extract, the instance should have a remote URI (it exists in the COD datastore)
+    assert is_remote(instance.dicom_uri) and instance.is_nested_in_tar
+    cod_obj.extract_locally()
+    # After we extract, the instance should be local and not nested in a tar
+    assert not is_remote(instance.dicom_uri) and not instance.is_nested_in_tar
+    # We should be able to open/read the instance in this state from this local tar file
+    with instance.open() as f:
+        ds = dcmread(f)
+        assert ds.StudyInstanceUID == test_study_uid
+        assert ds.SeriesInstanceUID == test_series_uid
+        assert ds.SOPInstanceUID == test_instance_uid
+
+
+def test_instance_read_after_sync(
+    gcs_client: storage.Client,
+    datastore_path: str,
+    local_instance_path: str,
+    test_study_uid: str,
+    test_series_uid: str,
+):
+    """Test that an instance can be read after a sync"""
+    with CODObject(
+        client=gcs_client,
+        datastore_path=datastore_path,
+        study_uid=test_study_uid,
+        series_uid=test_series_uid,
+        mode="w",
+    ) as cod_obj:
+        instance = Instance(dicom_uri=local_instance_path)
+        cod_obj.append([instance])
+        cod_obj._sync()
         with instance.open() as f:
             ds = dcmread(f)
-            self.assertEqual(ds.StudyInstanceUID, self.test_study_uid)
-            self.assertEqual(ds.SeriesInstanceUID, self.test_series_uid)
-            self.assertEqual(ds.SOPInstanceUID, self.test_instance_uid)
-
-    def test_extract_locally(self):
-        """Test that extract_locally extracts the tar and index to the local temp dir, and sets the dicom_uri of each instance to the local path"""
-        delete_uploaded_blobs(self.client, [self.datastore_path])
-        # append and sync an instance
-        instance = Instance(dicom_uri=self.local_instance_path)
-        with CODObject(
-            datastore_path=self.datastore_path,
-            client=self.client,
-            study_uid=self.test_study_uid,
-            series_uid=self.test_series_uid,
-            mode="w",
-        ) as cod_obj:
-            cod_obj.append([instance])
-            # sync happens automatically on context exit
-        cod_obj = CODObject(
-            datastore_path=self.datastore_path,
-            client=self.client,
-            study_uid=self.test_study_uid,
-            series_uid=self.test_series_uid,
-            mode="r",
-        )
-        instance = cod_obj.get_metadata().instances[self.test_instance_uid]
-        # Before we extract, the instance should have a remote URI (it exists in the COD datastore)
-        self.assertTrue(is_remote(instance.dicom_uri) and instance.is_nested_in_tar)
-        cod_obj.extract_locally()
-        # After we extract, the instance should be local and not nested in a tar
-        self.assertTrue(
-            not is_remote(instance.dicom_uri) and not instance.is_nested_in_tar
-        )
-        # We should be able to open/read the instance in this state from this local tar file
-        with instance.open() as f:
-            ds = dcmread(f)
-            self.assertEqual(ds.StudyInstanceUID, self.test_study_uid)
-            self.assertEqual(ds.SeriesInstanceUID, self.test_series_uid)
-            self.assertEqual(ds.SOPInstanceUID, self.test_instance_uid)
-
-    def test_instance_read_after_sync(self):
-        """Test that an instance can be read after a sync"""
-        delete_uploaded_blobs(self.client, [self.datastore_path])
-        with CODObject(
-            client=self.client,
-            datastore_path=self.datastore_path,
-            study_uid=self.test_study_uid,
-            series_uid=self.test_series_uid,
-            mode="w",
-        ) as cod_obj:
-            instance = Instance(dicom_uri=self.local_instance_path)
-            cod_obj.append([instance])
-            cod_obj._sync()
-            with instance.open() as f:
-                ds = dcmread(f)
-                self.assertEqual(ds.StudyInstanceUID, self.test_study_uid)
+            assert ds.StudyInstanceUID == test_study_uid

--- a/cloud_optimized_dicom/tests/test_concat.py
+++ b/cloud_optimized_dicom/tests/test_concat.py
@@ -2,11 +2,10 @@ import io
 import logging
 import os
 import tempfile
-import unittest
 
 import pydicom3
 import pydicom3.tag
-from google.api_core.client_options import ClientOptions
+import pytest
 from google.cloud import storage
 from google.cloud.storage.retry import DEFAULT_RETRY
 
@@ -74,6 +73,27 @@ GROUPING_INCLUDING_DUPE = {
     "files": [FILE1, FILE1_NEW_VERSION],
 }
 
+pytestmark = pytest.mark.skipif(
+    "SKIP_NETWORK_TESTS" in os.environ, reason="cloud storage"
+)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _enable_logging():
+    logging.basicConfig(level=logging.INFO)
+    logging.getLogger().setLevel(logging.INFO)
+
+
+@pytest.fixture(scope="module")
+def test_bucket(gcs_client: storage.Client) -> storage.Bucket:
+    return gcs_client.bucket(BUCKET_NAME)
+
+
+@pytest.fixture
+def clean_concat_paths(gcs_client: storage.Client):
+    delete_uploaded_blobs(gcs_client, [OUTPUT_URI, PLAYGROUND_URI_PREFIX])
+    yield
+
 
 def _copy_grouping_to_test_bucket(bucket: storage.Bucket, grouping: dict):
     for file in grouping["files"]:
@@ -88,346 +108,347 @@ def _copy_within_bucket(bucket: storage.Bucket, source_uri: str, dest_uri: str):
     bucket.copy_blob(source_blob, bucket, dest_blob_name, retry=DEFAULT_RETRY)
 
 
-@unittest.skipIf("SKIP_NETWORK_TESTS" in os.environ, reason="cloud storage")
-class TestConcat(unittest.TestCase):
+def _assert_metadata_equal(a: SeriesMetadata, b: SeriesMetadata):
+    # same series
+    assert a.study_uid == b.study_uid
+    assert a.series_uid == b.series_uid
+    # same number of instances
+    assert len(a.instances) == len(b.instances)
+    # every hash, uri, and size in a exists in b as well
+    # (actual byte ranges could differ)
+    b_data = {"hashes": [], "uris": [], "sizes": []}
+    for binstance_uid, binstance in b.instances.items():
+        b_data["hashes"].append(binstance.crc32c())
+        b_data["uris"].append(binstance.dicom_uri)
+        b_data["sizes"].append(binstance.size())
+    for ainstance_uid, ainstance in a.instances.items():
+        assert ainstance.crc32c() is not None
+        assert ainstance.dicom_uri is not None
+        assert ainstance.crc32c() in b_data["hashes"]
+        assert ainstance.dicom_uri in b_data["uris"]
+        assert ainstance.size() in b_data["sizes"]
 
-    @classmethod
-    def setUpClass(cls):
-        logging.basicConfig(level=logging.INFO)
-        logging.getLogger().setLevel(logging.INFO)
-        cls.client = storage.Client(
-            project="gradient-pacs-siskin-172863",
-            client_options=ClientOptions(
-                quota_project_id="gradient-pacs-siskin-172863"
-            ),
-        )
-        cls.bucket = cls.client.bucket(BUCKET_NAME)
 
-    def setUp(self):
-        # ensure clean test directory prior to test start
-        delete_uploaded_blobs(self.client, [OUTPUT_URI, PLAYGROUND_URI_PREFIX])
+def _assert_instances_dne(client: storage.Client, instances):
+    """assert the original uris of a group no longer exist"""
+    for instance in instances:
+        assert not storage.Blob.from_string(instance.dicom_uri, client=client).exists()
 
-    def _assert_metadata_equal(self, a: SeriesMetadata, b: SeriesMetadata):
-        # same series
-        self.assertEqual(a.study_uid, b.study_uid)
-        self.assertEqual(a.series_uid, b.series_uid)
-        # same number of instances
-        self.assertEqual(len(a.instances), len(b.instances))
-        # every hash, uri, and size in a exists in b as well
-        # (actual byte ranges could differ)
-        b_data = {"hashes": [], "uris": [], "sizes": []}
-        for binstance_uid, binstance in b.instances.items():
-            b_data["hashes"].append(binstance.crc32c())
-            b_data["uris"].append(binstance.dicom_uri)
-            b_data["sizes"].append(binstance.size())
-        for ainstance_uid, ainstance in a.instances.items():
-            self.assertIsNotNone(ainstance.crc32c())
-            self.assertIsNotNone(ainstance.dicom_uri)
-            self.assertIn(ainstance.crc32c(), b_data["hashes"])
-            self.assertIn(ainstance.dicom_uri, b_data["uris"])
-            self.assertIn(ainstance.size(), b_data["sizes"])
 
-    def _assert_instances_dne(self, instances: list[Instance]):
-        """assert the original uris of a group no longer exist"""
-        for instance in instances:
-            self.assertFalse(
-                storage.Blob.from_string(
-                    instance.dicom_uri, client=self.client
-                ).exists()
-            )
+def run_group(
+    gcs_client: storage.Client,
+    bucket: storage.Bucket,
+    grouping: dict,
+    dryrun: bool = False,
+) -> CODObject:
+    """Upload a series, confirm it uploaded, confirm it deleted original"""
+    _copy_grouping_to_test_bucket(bucket, grouping)
+    codobj_instance_pairs = query_result_to_codobjects(
+        gcs_client, grouping, OUTPUT_URI, validate_datastore_path=False
+    )
+    assert len(codobj_instance_pairs) == 1
+    cod_obj, instances = codobj_instance_pairs[0]
+    new, same, conflict, errors = cod_obj.append(instances)
+    cod_obj._sync()
+    assert len(errors) == 0
+    tar_blob = storage.Blob.from_string(cod_obj.tar_uri, client=gcs_client)
+    metadata_blob = storage.Blob.from_string(cod_obj.metadata_uri, client=gcs_client)
+    # confirm blobs that should exist, exist
+    assert tar_blob.exists(), f"{cod_obj.tar_uri} does not exist"
+    assert metadata_blob.exists(), f"{cod_obj.metadata_uri} does not exist"
+    metadata = SeriesMetadata.from_blob(metadata_blob)
+    if not dryrun:
+        for instance in new + same:
+            instance.delete_dependencies()
+        _assert_instances_dne(gcs_client, metadata.instances.values())
+    return cod_obj
 
-    def run_group(self, grouping: dict, dryrun=False):
-        """Upload a series, confirm it uploaded, confirm it deleted original"""
-        _copy_grouping_to_test_bucket(self.bucket, grouping)
-        codobj_instance_pairs = query_result_to_codobjects(
-            self.client, grouping, OUTPUT_URI, validate_datastore_path=False
-        )
-        self.assertEqual(len(codobj_instance_pairs), 1)
-        cod_obj, instances = codobj_instance_pairs[0]
-        new, same, conflict, errors = cod_obj.append(instances)
-        cod_obj._sync()
-        self.assertEqual(len(errors), 0)
-        tar_blob = storage.Blob.from_string(cod_obj.tar_uri, client=self.client)
+
+def test_single_instance(
+    gcs_client: storage.Client, test_bucket: storage.Bucket, clean_concat_paths
+):
+    """Upload single instance series, confirm it uploaded, confirm it deleted originals"""
+    config.debug()
+    with run_group(gcs_client, test_bucket, GROUPING_SINGLE) as cod_obj:
+        pass
+
+
+def test_pipeline_and_check_offsets(
+    gcs_client: storage.Client, test_bucket: storage.Bucket, clean_concat_paths
+):
+    """Upload a 3-instance series, confirm it uploaded, confirm you can read instance from tar using byte offsets"""
+    with run_group(gcs_client, test_bucket, GROUPING_FULL) as cod_obj:
+        with open(cod_obj.tar_file_path, "rb") as tar:
+            for instance in cod_obj._metadata.instances.values():
+                assert instance._byte_offsets is not None
+                tar.seek(instance._byte_offsets[0])
+                data = tar.read(instance._byte_offsets[1] - instance._byte_offsets[0])
+                with pydicom3.dcmread(io.BytesIO(data)) as ds:
+                    assert ds.SOPInstanceUID == instance.instance_uid()
+
+
+def test_dupe_instance(
+    gcs_client: storage.Client, test_bucket: storage.Bucket, clean_concat_paths
+):
+    """
+    Given instanceA, instanceB, and instanceC in a series,
+    upload all 3 in one run and confirm the result is the same as when they
+    are uploaded in 2 steps [instanceA, instanceB]; [instanceB, instanceC]
+    """
+    # get expected result of full upload
+    with run_group(gcs_client, test_bucket, GROUPING_FULL) as cod_obj:
+        # download normal bytes
+        tar_blob = storage.Blob.from_string(cod_obj.tar_uri, client=gcs_client)
+        tar_blob.download_as_bytes()
         metadata_blob = storage.Blob.from_string(
-            cod_obj.metadata_uri, client=self.client
-        )
-        # confirm blobs that should exist, exist
-        self.assertTrue(tar_blob.exists(), f"{cod_obj.tar_uri} does not exist")
-        self.assertTrue(
-            metadata_blob.exists(), f"{cod_obj.metadata_uri} does not exist"
+            cod_obj.metadata_uri, client=gcs_client
         )
         metadata = SeriesMetadata.from_blob(metadata_blob)
-        if not dryrun:
-            for instance in new + same:
-                instance.delete_dependencies()
-            self._assert_instances_dne(metadata.instances.values())
-        return cod_obj
+    # wipe GCS
+    delete_uploaded_blobs(gcs_client, [OUTPUT_URI, PLAYGROUND_URI_PREFIX])
+    # copy & upload first partial series
+    with run_group(gcs_client, test_bucket, GROUPING_FIRST_TWO) as cod_obj_first_two:
+        pass
+    # copy & upload second partial series
+    with run_group(gcs_client, test_bucket, GROUPING_LAST_TWO) as cod_obj_last_two:
+        # download duped bytes
+        # duped_content = tar_blob.download_as_bytes()
+        metadata_blob = storage.Blob.from_string(
+            cod_obj_last_two.metadata_uri, client=gcs_client
+        )
+        duped_metadata = SeriesMetadata.from_blob(metadata_blob)
+        # results are assumed to be identical if they are the same size and have equivalent metadata
+        # self.assertEqual(len(upload_content), len(duped_content))
+    _assert_metadata_equal(metadata, duped_metadata)
 
-    def test_single_instance(self):
-        """Upload single instance series, confirm it uploaded, confirm it deleted originals"""
-        config.debug()
-        with self.run_group(GROUPING_SINGLE) as cod_obj:
+
+def test_dupe_group(
+    gcs_client: storage.Client,
+    test_bucket: storage.Bucket,
+    clean_concat_paths,
+    caplog,
+):
+    """Upload the same group twice, confirm that instances were not fetched in second tar attempt"""
+    # Run a standard upload
+    with run_group(gcs_client, test_bucket, GROUPING_FULL) as cod_obj_full:
+        pass
+    # upload again, expecting 3 logs with "SKIP:DUPE_INSTANCE:SAME_HASH"
+    with caplog.at_level(logging.INFO):
+        with run_group(
+            gcs_client, test_bucket, GROUPING_FULL, dryrun=True
+        ) as cod_obj_full:
             pass
+    print("\n".join(caplog.messages))
+    # Filter logs that contain the same hash skip message
+    same_hash_skip_msg = "Skipping duplicate instance (same hash):"
+    same_hash_logs = [log for log in caplog.messages if same_hash_skip_msg in log]
+    # Assert that 3 logs with "SKIP:DUPE_INSTANCE:SAME_HASH" were logged
+    assert (
+        len(same_hash_logs) == 3
+    ), f"There should be 3 '{same_hash_skip_msg}' logs on second run"
+    # we also expect a "NO NEW INSTANCES" log
+    no_new_instances_msg = "No new instances:"
+    no_new_instances_logs = [
+        log for log in caplog.messages if no_new_instances_msg in log
+    ]
+    assert (
+        len(no_new_instances_logs) == 1
+    ), f"There should be exactly 1 '{no_new_instances_msg}' log on second run"
 
-    def test_pipeline_and_check_offsets(self):
-        """Upload a 3-instance series, confirm it uploaded, confirm you can read instance from tar using byte offsets"""
-        with self.run_group(GROUPING_FULL) as cod_obj:
-            with open(cod_obj.tar_file_path, "rb") as tar:
-                for instance in cod_obj._metadata.instances.values():
-                    self.assertIsNotNone(instance._byte_offsets)
-                    tar.seek(instance._byte_offsets[0])
-                    data = tar.read(
-                        instance._byte_offsets[1] - instance._byte_offsets[0]
-                    )
-                    with pydicom3.dcmread(io.BytesIO(data)) as ds:
-                        self.assertEqual(ds.SOPInstanceUID, instance.instance_uid())
 
-    def test_dupe_instance(self):
-        """
-        Given instanceA, instanceB, and instanceC in a series,
-        upload all 3 in one run and confirm the result is the same as when they
-        are uploaded in 2 steps [instanceA, instanceB]; [instanceB, instanceC]
-        """
-        # get expected result of full upload
-        with self.run_group(GROUPING_FULL) as cod_obj:
-            # download normal bytes
-            tar_blob = storage.Blob.from_string(cod_obj.tar_uri, client=self.client)
-            tar_blob.download_as_bytes()
-            metadata_blob = storage.Blob.from_string(
-                cod_obj.metadata_uri, client=self.client
-            )
-            metadata = SeriesMetadata.from_blob(metadata_blob)
-        # wipe GCS
-        delete_uploaded_blobs(self.client, [OUTPUT_URI, PLAYGROUND_URI_PREFIX])
-        # copy & upload first partial series
-        with self.run_group(GROUPING_FIRST_TWO) as cod_obj_first_two:
-            pass
-        # copy & upload second partial series
-        with self.run_group(GROUPING_LAST_TWO) as cod_obj_last_two:
-            # download duped bytes
-            # duped_content = tar_blob.download_as_bytes()
-            metadata_blob = storage.Blob.from_string(
-                cod_obj_last_two.metadata_uri, client=self.client
-            )
-            duped_metadata = SeriesMetadata.from_blob(metadata_blob)
-            # results are assumed to be identical if they are the same size and have equivalent metadata
-            # self.assertEqual(len(upload_content), len(duped_content))
-        self._assert_metadata_equal(metadata, duped_metadata)
+def test_diff_hash(
+    gcs_client: storage.Client,
+    test_bucket: storage.Bucket,
+    clean_concat_paths,
+    test_data_dir: str,
+):
+    """
+    Upload an instance and test what happens when a different version
+    of that same instance (same id, different hash) is uploaded subsequently.
+    We would expect to see this second version NOT DELETED (flagged for manual_review).
+    """
+    dcm_path = os.path.join(test_data_dir, "monochrome2.dcm")
+    # upload a version of the dicom
+    v1_uri = f"{PLAYGROUND_URI_PREFIX}/version1.dcm"
+    v2_uri = f"{PLAYGROUND_URI_PREFIX}/version2.dcm"
+    v1_blob = storage.Blob.from_string(v1_uri, client=gcs_client)
+    v2_blob = storage.Blob.from_string(v2_uri, client=gcs_client)
+    v1_blob.upload_from_filename(dcm_path)
+    # change something (cause hash mismatch)
+    ds = pydicom3.dcmread(dcm_path)
+    study_uid = getattr(ds, "StudyInstanceUID")
+    series_uid = getattr(ds, "SeriesInstanceUID")
+    instance_uid = getattr(ds, "SOPInstanceUID")
+    ds.add_new(pydicom3.tag.Tag(0x6001, 0x0010), "LO", "Gradient Health")
+    with tempfile.NamedTemporaryFile() as temp_file:
+        ds.save_as(temp_file.name)
+        v2_blob.upload_from_filename(temp_file.name)
 
-    def test_dupe_group(self):
-        """Upload the same group twice, confirm that instances were not fetched in second tar attempt"""
-        # Run a standard upload
-        with self.run_group(GROUPING_FULL) as cod_obj_full:
-            pass
-        # upload again, expecting 3 logs with "SKIP:DUPE_INSTANCE:SAME_HASH"
-        with self.assertLogs(level="INFO") as log_capture_second:
-            with self.run_group(GROUPING_FULL, dryrun=True) as cod_obj_full:
-                pass
-        print("\n".join(log_capture_second.output))
-        # Filter logs that contain the same hash skip message
-        same_hash_skip_msg = "Skipping duplicate instance (same hash):"
-        same_hash_logs = [
-            log for log in log_capture_second.output if same_hash_skip_msg in log
-        ]
-        # Assert that 3 logs with "SKIP:DUPE_INSTANCE:SAME_HASH" were logged
-        self.assertEqual(
-            len(same_hash_logs),
-            3,
-            f"There should be 3 '{same_hash_skip_msg}' logs on second run",
+    # blobs should have different hashes
+    assert v1_blob.crc32c != v2_blob.crc32c
+
+    with CODObject(
+        study_uid=study_uid,
+        series_uid=series_uid,
+        datastore_path=OUTPUT_URI,
+        client=gcs_client,
+        mode="w",
+    ) as cod_obj:
+        instance_v1 = Instance(
+            dicom_uri=v1_uri,
+            hints=Hints(instance_uid=instance_uid),
         )
-        # we also expect a "NO NEW INSTANCES" log
-        no_new_instances_msg = "No new instances:"
-        no_new_instances_logs = [
-            log for log in log_capture_second.output if no_new_instances_msg in log
-        ]
-        self.assertEqual(
-            len(no_new_instances_logs),
-            1,
-            f"There should be exactly 1 '{no_new_instances_msg}' log on second run",
+        instance_v2 = Instance(
+            dicom_uri=v2_uri,
+            hints=Hints(instance_uid=instance_uid),
         )
-
-    def test_diff_hash(self):
-        """
-        Upload an instance and test what happens when a different version
-        of that same instance (same id, different hash) is uploaded subsequently.
-        We would expect to see this second version NOT DELETED (flagged for manual_review).
-        """
-        dcm_path = os.path.join(
-            os.path.dirname(os.path.abspath(__file__)), "test_data", "monochrome2.dcm"
+        # append v1 and sync
+        cod_obj.append([instance_v1])
+        cod_obj._sync()
+        metadata_blob = storage.Blob.from_string(
+            cod_obj.metadata_uri, client=gcs_client
         )
-        # upload a version of the dicom
-        v1_uri = f"{PLAYGROUND_URI_PREFIX}/version1.dcm"
-        v2_uri = f"{PLAYGROUND_URI_PREFIX}/version2.dcm"
-        v1_blob = storage.Blob.from_string(v1_uri, client=self.client)
-        v2_blob = storage.Blob.from_string(v2_uri, client=self.client)
-        v1_blob.upload_from_filename(dcm_path)
-        # change something (cause hash mismatch)
-        ds = pydicom3.dcmread(dcm_path)
-        study_uid = getattr(ds, "StudyInstanceUID")
-        series_uid = getattr(ds, "SeriesInstanceUID")
-        instance_uid = getattr(ds, "SOPInstanceUID")
-        ds.add_new(pydicom3.tag.Tag(0x6001, 0x0010), "LO", "Gradient Health")
-        with tempfile.NamedTemporaryFile() as temp_file:
-            ds.save_as(temp_file.name)
-            v2_blob.upload_from_filename(temp_file.name)
-
-        # blobs should have different hashes
-        self.assertNotEqual(v1_blob.crc32c, v2_blob.crc32c)
-
-        with CODObject(
-            study_uid=study_uid,
-            series_uid=series_uid,
-            datastore_path=OUTPUT_URI,
-            client=self.client,
-            mode="w",
-        ) as cod_obj:
-            instance_v1 = Instance(
-                dicom_uri=v1_uri,
-                hints=Hints(instance_uid=instance_uid),
-            )
-            instance_v2 = Instance(
-                dicom_uri=v2_uri,
-                hints=Hints(instance_uid=instance_uid),
-            )
-            # append v1 and sync
-            cod_obj.append([instance_v1])
-            cod_obj._sync()
-            metadata_blob = storage.Blob.from_string(
-                cod_obj.metadata_uri, client=self.client
-            )
-            self.assertTrue(metadata_blob.exists())
-            # append v2 and sync
-            cod_obj.append([instance_v2])
-            # metadata should be desynced (diff hash dupe found), but tar should be synced
-            self.assertFalse(cod_obj._metadata_synced)
-            self.assertTrue(cod_obj._tar_synced)
-            cod_obj._sync()
-            # file should still exist; deletion should be skipped due to same instance diff hash
-            self.assertTrue(v2_blob.exists())
-            # download the metadata and confirm diff hash duplicate was logged
-            metadata_blob = storage.Blob.from_string(
-                cod_obj.metadata_uri, client=self.client
-            )
-            duped_metadata = SeriesMetadata.from_blob(metadata_blob)
-            populated_dupe_list = duped_metadata.instances.get(
-                instance_v1.instance_uid(trust_hints_if_available=True)
-            )._diff_hash_dupe_paths
-            self.assertEqual(len(populated_dupe_list), 1)
-            self.assertEqual(populated_dupe_list[0], v2_uri)
-
-    def test_diff_hash_pixeldata(self):
-        """
-        Upload an instance and test what happens when a different version
-        of that same instance (same id, different hash - PIXELDATA) is uploaded subsequently.
-        We would expect to see this second version NOT DELETED (flagged for manual_review).
-        """
-        dcm_path = os.path.join(
-            os.path.dirname(os.path.abspath(__file__)), "test_data", "monochrome1.dcm"
+        assert metadata_blob.exists()
+        # append v2 and sync
+        cod_obj.append([instance_v2])
+        # metadata should be desynced (diff hash dupe found), but tar should be synced
+        assert not cod_obj._metadata_synced
+        assert cod_obj._tar_synced
+        cod_obj._sync()
+        # file should still exist; deletion should be skipped due to same instance diff hash
+        assert v2_blob.exists()
+        # download the metadata and confirm diff hash duplicate was logged
+        metadata_blob = storage.Blob.from_string(
+            cod_obj.metadata_uri, client=gcs_client
         )
-        # upload a version of the dicom
-        v1_uri = f"{PLAYGROUND_URI_PREFIX}/version1.dcm"
-        v2_uri = f"{PLAYGROUND_URI_PREFIX}/version2.dcm"
-        v1_blob = storage.Blob.from_string(v1_uri, client=self.client)
-        v2_blob = storage.Blob.from_string(v2_uri, client=self.client)
-        v1_blob.upload_from_filename(dcm_path, retry=DEFAULT_RETRY)
-        # load ds & cause hash mismatch in pixel data
-        ds = pydicom3.dcmread(dcm_path)
-        study_uid = getattr(ds, "StudyInstanceUID")
-        series_uid = getattr(ds, "SeriesInstanceUID")
-        getattr(ds, "SOPInstanceUID")
-        # flip all bits in 1000th byte (to cause hash mismatch)
-        pixel_bytes = bytearray(ds.PixelData)
-        pixel_bytes[1000] ^= 0xFF
-        ds.PixelData = bytes(pixel_bytes)
-        with tempfile.NamedTemporaryFile() as temp_file:
-            ds.save_as(temp_file.name)
-            v2_blob.upload_from_filename(temp_file.name, retry=DEFAULT_RETRY)
+        duped_metadata = SeriesMetadata.from_blob(metadata_blob)
+        populated_dupe_list = duped_metadata.instances.get(
+            instance_v1.instance_uid(trust_hints_if_available=True)
+        )._diff_hash_dupe_paths
+        assert len(populated_dupe_list) == 1
+        assert populated_dupe_list[0] == v2_uri
 
-        # blobs should have different hashes
-        self.assertNotEqual(v1_blob.crc32c, v2_blob.crc32c)
 
-        with CODObject(
-            datastore_path=OUTPUT_URI,
-            client=self.client,
-            study_uid=study_uid,
-            series_uid=series_uid,
-            mode="w",
-        ) as cod_obj:
-            instance_v1 = Instance(v1_uri)
-            instance_v2 = Instance(v2_uri)
-            # append v1 and sync
-            cod_obj.append([instance_v1])
-            cod_obj._sync()
-            # append v2 and sync
-            cod_obj.append([instance_v2], treat_metadata_diffs_as_same=True)
-            # metadata should be desynced (diff hash dupe found), but tar should be synced
-            self.assertFalse(cod_obj._metadata_synced)
-            self.assertTrue(cod_obj._tar_synced)
-            cod_obj._sync()
-            # file should still exist; deletion should be skipped due to same instance diff hash
-            self.assertTrue(v2_blob.exists())
-            # download the metadata and confirm diff hash duplicate was logged
-            metadata_blob = storage.Blob.from_string(
-                cod_obj.metadata_uri, client=self.client
-            )
-            duped_metadata = SeriesMetadata.from_blob(metadata_blob)
-            populated_dupe_list = duped_metadata.instances.get(
-                instance_v1.instance_uid(trust_hints_if_available=True)
-            )._diff_hash_dupe_paths
-            self.assertEqual(len(populated_dupe_list), 1)
-            self.assertEqual(populated_dupe_list[0], v2_uri)
+def test_diff_hash_pixeldata(
+    gcs_client: storage.Client,
+    test_bucket: storage.Bucket,
+    clean_concat_paths,
+    test_data_dir: str,
+):
+    """
+    Upload an instance and test what happens when a different version
+    of that same instance (same id, different hash - PIXELDATA) is uploaded subsequently.
+    We would expect to see this second version NOT DELETED (flagged for manual_review).
+    """
+    dcm_path = os.path.join(test_data_dir, "monochrome1.dcm")
+    # upload a version of the dicom
+    v1_uri = f"{PLAYGROUND_URI_PREFIX}/version1.dcm"
+    v2_uri = f"{PLAYGROUND_URI_PREFIX}/version2.dcm"
+    v1_blob = storage.Blob.from_string(v1_uri, client=gcs_client)
+    v2_blob = storage.Blob.from_string(v2_uri, client=gcs_client)
+    v1_blob.upload_from_filename(dcm_path, retry=DEFAULT_RETRY)
+    # load ds & cause hash mismatch in pixel data
+    ds = pydicom3.dcmread(dcm_path)
+    study_uid = getattr(ds, "StudyInstanceUID")
+    series_uid = getattr(ds, "SeriesInstanceUID")
+    getattr(ds, "SOPInstanceUID")
+    # flip all bits in 1000th byte (to cause hash mismatch)
+    pixel_bytes = bytearray(ds.PixelData)
+    pixel_bytes[1000] ^= 0xFF
+    ds.PixelData = bytes(pixel_bytes)
+    with tempfile.NamedTemporaryFile() as temp_file:
+        ds.save_as(temp_file.name)
+        v2_blob.upload_from_filename(temp_file.name, retry=DEFAULT_RETRY)
 
-    def test_repeat_in_input(self):
-        """
-        Test behavior when the same instance is supplied multiple times.
-        We expect the duplicate(s) to get skipped.
-        Tests two scenarios:
-         - duplicates & singles: [instanceA, instanceB, instanceB]
-         - only duplicates: [instanceA, instanceA]
-        """
-        _copy_grouping_to_test_bucket(self.bucket, GROUPING_INCLUDING_DUPE)
-        codobj_instance_pairs = query_result_to_codobjects(
-            self.client,
-            GROUPING_INCLUDING_DUPE,
-            OUTPUT_URI,
-            validate_datastore_path=False,
+    # blobs should have different hashes
+    assert v1_blob.crc32c != v2_blob.crc32c
+
+    with CODObject(
+        datastore_path=OUTPUT_URI,
+        client=gcs_client,
+        study_uid=study_uid,
+        series_uid=series_uid,
+        mode="w",
+    ) as cod_obj:
+        instance_v1 = Instance(v1_uri)
+        instance_v2 = Instance(v2_uri)
+        # append v1 and sync
+        cod_obj.append([instance_v1])
+        cod_obj._sync()
+        # append v2 and sync
+        cod_obj.append([instance_v2], treat_metadata_diffs_as_same=True)
+        # metadata should be desynced (diff hash dupe found), but tar should be synced
+        assert not cod_obj._metadata_synced
+        assert cod_obj._tar_synced
+        cod_obj._sync()
+        # file should still exist; deletion should be skipped due to same instance diff hash
+        assert v2_blob.exists()
+        # download the metadata and confirm diff hash duplicate was logged
+        metadata_blob = storage.Blob.from_string(
+            cod_obj.metadata_uri, client=gcs_client
         )
-        cod_obj, instances = codobj_instance_pairs[0]
-        append_result = cod_obj.append(instances)
-        # expect 1 new, 1 same, 0 other
-        self.assertEqual(len(append_result.new), 1)
-        self.assertEqual(len(append_result.same), 1)
-        self.assertEqual(len(append_result.conflict), 0)
-        self.assertEqual(len(append_result.errors), 0)
-
-    def test_error_overlarge_instances(self):
-        """Expect instances to be skipped if they are too large"""
-        # set max size to 100 bytes; pipeline should raise ValueError
-        _copy_grouping_to_test_bucket(self.bucket, GROUPING_FULL)
-        codobj_instance_pairs = query_result_to_codobjects(
-            self.client, GROUPING_FULL, OUTPUT_URI, validate_datastore_path=False
-        )
-        cod_obj, instances = codobj_instance_pairs[0]
-        max_instance_size = 10000 / 1073741824
-        new, same, conflict, errors = cod_obj.append(
-            instances, max_instance_size=max_instance_size
-        )
-        self.assertEqual(len(new), 0)
-        self.assertEqual(len(same), 0)
-        self.assertEqual(len(conflict), 0)
-        self.assertEqual(len(errors), 3)
-
-    def test_error_overlarge_series(self):
-        """Expect a ValueError if series is too large"""
-        codobj_instance_pairs = query_result_to_codobjects(
-            self.client, GROUPING_FULL, OUTPUT_URI, validate_datastore_path=False
-        )
-        cod_obj, instances = codobj_instance_pairs[0]
-        max_series_size = 10000 / 1073741824
-        with self.assertRaises(ValueError):
-            cod_obj.append(instances, max_series_size=max_series_size)
+        duped_metadata = SeriesMetadata.from_blob(metadata_blob)
+        populated_dupe_list = duped_metadata.instances.get(
+            instance_v1.instance_uid(trust_hints_if_available=True)
+        )._diff_hash_dupe_paths
+        assert len(populated_dupe_list) == 1
+        assert populated_dupe_list[0] == v2_uri
 
 
-if __name__ == "__main__":
-    # SISKIN_ENV_ENABLED=1 python -m unittest components.cloud_optimized_dicom.tests.test_concat.TestPipelineFunctions.test_cod_obj
-    unittest.main()
+def test_repeat_in_input(
+    gcs_client: storage.Client, test_bucket: storage.Bucket, clean_concat_paths
+):
+    """
+    Test behavior when the same instance is supplied multiple times.
+    We expect the duplicate(s) to get skipped.
+    Tests two scenarios:
+     - duplicates & singles: [instanceA, instanceB, instanceB]
+     - only duplicates: [instanceA, instanceA]
+    """
+    _copy_grouping_to_test_bucket(test_bucket, GROUPING_INCLUDING_DUPE)
+    codobj_instance_pairs = query_result_to_codobjects(
+        gcs_client,
+        GROUPING_INCLUDING_DUPE,
+        OUTPUT_URI,
+        validate_datastore_path=False,
+    )
+    cod_obj, instances = codobj_instance_pairs[0]
+    append_result = cod_obj.append(instances)
+    # expect 1 new, 1 same, 0 other
+    assert len(append_result.new) == 1
+    assert len(append_result.same) == 1
+    assert len(append_result.conflict) == 0
+    assert len(append_result.errors) == 0
+
+
+def test_error_overlarge_instances(
+    gcs_client: storage.Client, test_bucket: storage.Bucket, clean_concat_paths
+):
+    """Expect instances to be skipped if they are too large"""
+    # set max size to 100 bytes; pipeline should raise ValueError
+    _copy_grouping_to_test_bucket(test_bucket, GROUPING_FULL)
+    codobj_instance_pairs = query_result_to_codobjects(
+        gcs_client, GROUPING_FULL, OUTPUT_URI, validate_datastore_path=False
+    )
+    cod_obj, instances = codobj_instance_pairs[0]
+    max_instance_size = 10000 / 1073741824
+    new, same, conflict, errors = cod_obj.append(
+        instances, max_instance_size=max_instance_size
+    )
+    assert len(new) == 0
+    assert len(same) == 0
+    assert len(conflict) == 0
+    assert len(errors) == 3
+
+
+def test_error_overlarge_series(
+    gcs_client: storage.Client, test_bucket: storage.Bucket, clean_concat_paths
+):
+    """Expect a ValueError if series is too large"""
+    codobj_instance_pairs = query_result_to_codobjects(
+        gcs_client, GROUPING_FULL, OUTPUT_URI, validate_datastore_path=False
+    )
+    cod_obj, instances = codobj_instance_pairs[0]
+    max_series_size = 10000 / 1073741824
+    with pytest.raises(ValueError):
+        cod_obj.append(instances, max_series_size=max_series_size)

--- a/cloud_optimized_dicom/tests/test_custom_offset_tables.py
+++ b/cloud_optimized_dicom/tests/test_custom_offset_tables.py
@@ -1,11 +1,11 @@
 import random
 from io import BytesIO
-from unittest.mock import patch
 
 import numpy as np
 import pydicom3
 import pydicom3.encaps
 import pydicom3.errors
+from pytest_mock import MockerFixture
 
 from cloud_optimized_dicom.custom_offset_tables import get_multiframe_offset_tables
 
@@ -171,50 +171,46 @@ def test_singleframe_encapsulated_pixeldata():
     assert "CustomOffsetTableLengths" not in result
 
 
-@patch("cloud_optimized_dicom.custom_offset_tables.logger.warning")
-@patch(
-    "cloud_optimized_dicom.custom_offset_tables._generate_pixel_data_fragment_offsets"
-)
-def test_multiframe_raise_value_error(
-    mock_generate_pixel_data_fragment_offsets,
-    mock_logging_warning,
-):
+def test_multiframe_raise_value_error(mocker: MockerFixture):
+    mock_generate = mocker.patch(
+        "cloud_optimized_dicom.custom_offset_tables._generate_pixel_data_fragment_offsets"
+    )
+    mock_warning = mocker.patch(
+        "cloud_optimized_dicom.custom_offset_tables.logger.warning"
+    )
     dataset = create_sample_dataset(
         number_of_frames=5,
         is_pixeldata_encapsulated=False,
         include_eot=False,
         include_bot=False,
     )
-    mock_generate_pixel_data_fragment_offsets.side_effect = ValueError("Test error")
+    mock_generate.side_effect = ValueError("Test error")
 
     get_multiframe_offset_tables(dataset)
 
-    mock_logging_warning.assert_called_once_with(
+    mock_warning.assert_called_once_with(
         "Some errors occured when creating Offset table"
     )
 
 
-@patch("cloud_optimized_dicom.custom_offset_tables.logger.warning")
-@patch(
-    "cloud_optimized_dicom.custom_offset_tables._generate_pixel_data_fragment_offsets"
-)
-def test_multiframe_raise_invalid_dicom_error(
-    mock_generate_pixel_data_fragment_offsets,
-    mock_logging_warning,
-):
+def test_multiframe_raise_invalid_dicom_error(mocker: MockerFixture):
+    mock_generate = mocker.patch(
+        "cloud_optimized_dicom.custom_offset_tables._generate_pixel_data_fragment_offsets"
+    )
+    mock_warning = mocker.patch(
+        "cloud_optimized_dicom.custom_offset_tables.logger.warning"
+    )
     dataset = create_sample_dataset(
         number_of_frames=5,
         is_pixeldata_encapsulated=False,
         include_eot=False,
         include_bot=False,
     )
-    mock_generate_pixel_data_fragment_offsets.side_effect = (
-        pydicom3.errors.InvalidDicomError("Test error")
-    )
+    mock_generate.side_effect = pydicom3.errors.InvalidDicomError("Test error")
 
     get_multiframe_offset_tables(dataset)
 
-    mock_logging_warning.assert_called_once_with("Test error")
+    mock_warning.assert_called_once_with("Test error")
 
 
 def test_pixeldata_is_none():

--- a/cloud_optimized_dicom/tests/test_custom_offset_tables.py
+++ b/cloud_optimized_dicom/tests/test_custom_offset_tables.py
@@ -1,5 +1,4 @@
 import random
-import unittest
 from io import BytesIO
 from unittest.mock import patch
 
@@ -84,159 +83,156 @@ def create_sample_dataset(
     return ds
 
 
-class TestMultiframeOffsetTable(unittest.TestCase):
-    def test_multiframe_with_basic_offset_table(self):
-        custom_offset_table = [[512, 720, 928, 1136, 1344], [200, 200, 200, 200, 200]]
-        dataset = create_sample_dataset(
-            number_of_frames=5,
-            is_pixeldata_encapsulated=True,
-            include_eot=False,
-            include_bot=True,
-        )
-
-        result = get_multiframe_offset_tables(dataset)
-
-        assert result.get("CustomOffsetTable") == custom_offset_table[0]
-        assert result.get("CustomOffsetTableLengths") == custom_offset_table[1]
-
-    def test_multiframe_with_extended_offset_table(self):
-        custom_offset_table = [[492, 700, 908, 1116, 1324], [200, 200, 200, 200, 200]]
-        dataset = create_sample_dataset(
-            number_of_frames=5,
-            is_pixeldata_encapsulated=True,
-            include_eot=True,
-            include_bot=False,
-        )
-
-        result = get_multiframe_offset_tables(dataset)
-
-        assert result.get("CustomOffsetTable") == custom_offset_table[0]
-        assert result.get("CustomOffsetTableLengths") == custom_offset_table[1]
-
-    def test_multiframe_without_offset_table(self):
-        custom_offset_table = [[492, 700, 908, 1116, 1324], [200, 200, 200, 200, 200]]
-        dataset = create_sample_dataset(
-            number_of_frames=5,
-            is_pixeldata_encapsulated=True,
-            include_eot=False,
-            include_bot=False,
-        )
-
-        result = get_multiframe_offset_tables(dataset)
-
-        assert result.get("CustomOffsetTable") == custom_offset_table[0]
-        assert result.get("CustomOffsetTableLengths") == custom_offset_table[1]
-
-    def test_multiframe_with_uncompressed_pixeldata(self):
-        custom_offset_table = [[484, 684, 884, 1084, 1284], [200, 200, 200, 200, 200]]
-        dataset = create_sample_dataset(
-            number_of_frames=5,
-            is_pixeldata_encapsulated=False,
-            include_eot=False,
-            include_bot=False,
-        )
-
-        result = get_multiframe_offset_tables(dataset)
-
-        assert result.get("CustomOffsetTable") == custom_offset_table[0]
-        assert result.get("CustomOffsetTableLengths") == custom_offset_table[1]
-
-    def test_singleframe_uncompressed_pixeldata(self):
-        dataset = create_sample_dataset(
-            number_of_frames=1,
-            is_pixeldata_encapsulated=False,
-            include_eot=False,
-            include_bot=False,
-        )
-
-        result = get_multiframe_offset_tables(dataset)
-
-        assert "CustomOffsetTable" not in result
-        assert "CustomOffsetTableLengths" not in result
-
-    def test_singleframe_encapsulated_pixeldata(self):
-        dataset = create_sample_dataset(
-            number_of_frames=1,
-            is_pixeldata_encapsulated=True,
-            include_eot=False,
-            include_bot=False,
-        )
-
-        result = get_multiframe_offset_tables(dataset)
-
-        assert "CustomOffsetTable" not in result
-        assert "CustomOffsetTableLengths" not in result
-
-    @patch("cloud_optimized_dicom.custom_offset_tables.logger.warning")
-    @patch(
-        "cloud_optimized_dicom.custom_offset_tables._generate_pixel_data_fragment_offsets"
+def test_multiframe_with_basic_offset_table():
+    custom_offset_table = [[512, 720, 928, 1136, 1344], [200, 200, 200, 200, 200]]
+    dataset = create_sample_dataset(
+        number_of_frames=5,
+        is_pixeldata_encapsulated=True,
+        include_eot=False,
+        include_bot=True,
     )
-    def test_multiframe_raise_value_error(
-        self,
-        mock_generate_pixel_data_fragment_offsets,
-        mock_logging_warning,
-    ):
-        dataset = create_sample_dataset(
-            number_of_frames=5,
-            is_pixeldata_encapsulated=False,
-            include_eot=False,
-            include_bot=False,
-        )
-        mock_generate_pixel_data_fragment_offsets.side_effect = ValueError("Test error")
 
-        get_multiframe_offset_tables(dataset)
+    result = get_multiframe_offset_tables(dataset)
 
-        mock_logging_warning.assert_called_once_with(
-            "Some errors occured when creating Offset table"
-        )
+    assert result.get("CustomOffsetTable") == custom_offset_table[0]
+    assert result.get("CustomOffsetTableLengths") == custom_offset_table[1]
 
-    @patch("cloud_optimized_dicom.custom_offset_tables.logger.warning")
-    @patch(
-        "cloud_optimized_dicom.custom_offset_tables._generate_pixel_data_fragment_offsets"
+
+def test_multiframe_with_extended_offset_table():
+    custom_offset_table = [[492, 700, 908, 1116, 1324], [200, 200, 200, 200, 200]]
+    dataset = create_sample_dataset(
+        number_of_frames=5,
+        is_pixeldata_encapsulated=True,
+        include_eot=True,
+        include_bot=False,
     )
-    def test_multiframe_raise_invalid_dicom_error(
-        self,
-        mock_generate_pixel_data_fragment_offsets,
-        mock_logging_warning,
-    ):
-        dataset = create_sample_dataset(
-            number_of_frames=5,
-            is_pixeldata_encapsulated=False,
-            include_eot=False,
-            include_bot=False,
-        )
-        mock_generate_pixel_data_fragment_offsets.side_effect = (
-            pydicom3.errors.InvalidDicomError("Test error")
-        )
 
-        get_multiframe_offset_tables(dataset)
+    result = get_multiframe_offset_tables(dataset)
 
-        mock_logging_warning.assert_called_once_with("Test error")
-
-    def test_pixeldata_is_none(self):
-        """Edge case where the pixeldata attribute is present, but is None"""
-        dataset = create_sample_dataset(
-            number_of_frames=2, is_pixeldata_encapsulated=False
-        )
-        dataset.PixelData = None
-
-        result = get_multiframe_offset_tables(dataset)
-
-        assert result.get("CustomOffsetTable") is None
-        assert result.get("CustomOffsetTableLengths") is None
-
-    def test_no_pixeldata_attribute(self):
-        dataset = create_sample_dataset(
-            number_of_frames=2, is_pixeldata_encapsulated=False
-        )
-        del dataset.PixelData
-
-        result = get_multiframe_offset_tables(dataset)
-
-        assert result.get("CustomOffsetTable") is None
-        assert result.get("CustomOffsetTableLengths") is None
+    assert result.get("CustomOffsetTable") == custom_offset_table[0]
+    assert result.get("CustomOffsetTableLengths") == custom_offset_table[1]
 
 
-if __name__ == "__main__":
-    # python3 -m unittest components.cloud_optimized_dicom.tests.test_multiframe_offset_table
-    unittest.main()
+def test_multiframe_without_offset_table():
+    custom_offset_table = [[492, 700, 908, 1116, 1324], [200, 200, 200, 200, 200]]
+    dataset = create_sample_dataset(
+        number_of_frames=5,
+        is_pixeldata_encapsulated=True,
+        include_eot=False,
+        include_bot=False,
+    )
+
+    result = get_multiframe_offset_tables(dataset)
+
+    assert result.get("CustomOffsetTable") == custom_offset_table[0]
+    assert result.get("CustomOffsetTableLengths") == custom_offset_table[1]
+
+
+def test_multiframe_with_uncompressed_pixeldata():
+    custom_offset_table = [[484, 684, 884, 1084, 1284], [200, 200, 200, 200, 200]]
+    dataset = create_sample_dataset(
+        number_of_frames=5,
+        is_pixeldata_encapsulated=False,
+        include_eot=False,
+        include_bot=False,
+    )
+
+    result = get_multiframe_offset_tables(dataset)
+
+    assert result.get("CustomOffsetTable") == custom_offset_table[0]
+    assert result.get("CustomOffsetTableLengths") == custom_offset_table[1]
+
+
+def test_singleframe_uncompressed_pixeldata():
+    dataset = create_sample_dataset(
+        number_of_frames=1,
+        is_pixeldata_encapsulated=False,
+        include_eot=False,
+        include_bot=False,
+    )
+
+    result = get_multiframe_offset_tables(dataset)
+
+    assert "CustomOffsetTable" not in result
+    assert "CustomOffsetTableLengths" not in result
+
+
+def test_singleframe_encapsulated_pixeldata():
+    dataset = create_sample_dataset(
+        number_of_frames=1,
+        is_pixeldata_encapsulated=True,
+        include_eot=False,
+        include_bot=False,
+    )
+
+    result = get_multiframe_offset_tables(dataset)
+
+    assert "CustomOffsetTable" not in result
+    assert "CustomOffsetTableLengths" not in result
+
+
+@patch("cloud_optimized_dicom.custom_offset_tables.logger.warning")
+@patch(
+    "cloud_optimized_dicom.custom_offset_tables._generate_pixel_data_fragment_offsets"
+)
+def test_multiframe_raise_value_error(
+    mock_generate_pixel_data_fragment_offsets,
+    mock_logging_warning,
+):
+    dataset = create_sample_dataset(
+        number_of_frames=5,
+        is_pixeldata_encapsulated=False,
+        include_eot=False,
+        include_bot=False,
+    )
+    mock_generate_pixel_data_fragment_offsets.side_effect = ValueError("Test error")
+
+    get_multiframe_offset_tables(dataset)
+
+    mock_logging_warning.assert_called_once_with(
+        "Some errors occured when creating Offset table"
+    )
+
+
+@patch("cloud_optimized_dicom.custom_offset_tables.logger.warning")
+@patch(
+    "cloud_optimized_dicom.custom_offset_tables._generate_pixel_data_fragment_offsets"
+)
+def test_multiframe_raise_invalid_dicom_error(
+    mock_generate_pixel_data_fragment_offsets,
+    mock_logging_warning,
+):
+    dataset = create_sample_dataset(
+        number_of_frames=5,
+        is_pixeldata_encapsulated=False,
+        include_eot=False,
+        include_bot=False,
+    )
+    mock_generate_pixel_data_fragment_offsets.side_effect = (
+        pydicom3.errors.InvalidDicomError("Test error")
+    )
+
+    get_multiframe_offset_tables(dataset)
+
+    mock_logging_warning.assert_called_once_with("Test error")
+
+
+def test_pixeldata_is_none():
+    """Edge case where the pixeldata attribute is present, but is None"""
+    dataset = create_sample_dataset(number_of_frames=2, is_pixeldata_encapsulated=False)
+    dataset.PixelData = None
+
+    result = get_multiframe_offset_tables(dataset)
+
+    assert result.get("CustomOffsetTable") is None
+    assert result.get("CustomOffsetTableLengths") is None
+
+
+def test_no_pixeldata_attribute():
+    dataset = create_sample_dataset(number_of_frames=2, is_pixeldata_encapsulated=False)
+    del dataset.PixelData
+
+    result = get_multiframe_offset_tables(dataset)
+
+    assert result.get("CustomOffsetTable") is None
+    assert result.get("CustomOffsetTableLengths") is None

--- a/cloud_optimized_dicom/tests/test_dicomweb.py
+++ b/cloud_optimized_dicom/tests/test_dicomweb.py
@@ -1,7 +1,6 @@
 import os
-import unittest
 
-from google.api_core.client_options import ClientOptions
+import pytest
 from google.cloud import storage
 
 from cloud_optimized_dicom.dicomweb import (
@@ -11,178 +10,180 @@ from cloud_optimized_dicom.dicomweb import (
     is_valid_uid,
 )
 
-
-class TestDicomweb(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        cls.datastore_path = "gs://siskin-172863-pacs/v1.0/dicomweb"
-        cls.client = storage.Client(
-            project="gradient-pacs-siskin-172863",
-            client_options=ClientOptions(
-                quota_project_id="gradient-pacs-siskin-172863"
-            ),
-        )
-
-    def test_get_series_uid_from_blob_iterator(self):
-        """
-        Test that the series uid can be extracted from all standard COD blobs
-        """
-        # simulate iterators returning every possible blob first
-        series_uid = "1.2.826.0.1.3680043.8.498.89840699185761593370876698622882853150"
-        series_uri = os.path.join(
-            self.datastore_path,
-            "studies",
-            "1.2.826.0.1.3680043.8.498.18783474219392509401504861043428417882",
-            "series",
-            series_uid,
-        )
-        tar_iter = iter([storage.Blob.from_string(f"{series_uri}.tar")])
-        metadata_iter = iter(
-            [storage.Blob.from_string(os.path.join(series_uri, "metadata.json"))]
-        )
-        index_iter = iter(
-            [storage.Blob.from_string(os.path.join(series_uri, "index.sqlite"))]
-        )
-        thumbnail_iter = iter(
-            [storage.Blob.from_string(os.path.join(series_uri, "thumbnail.mp4"))]
-        )
-        lock_iter = iter(
-            [storage.Blob.from_string(os.path.join(series_uri, ".gradient.lock"))]
-        )
-        junk_iter = iter([storage.Blob.from_string(f"gs://this/is/a/junk/blob")])
-
-        # make sure that no matter which blob the iterator returns, the series uid is extracted correctly
-        self.assertEqual(_get_series_uid_from_blob_iterator(tar_iter), series_uid)
-        self.assertEqual(_get_series_uid_from_blob_iterator(metadata_iter), series_uid)
-        self.assertEqual(_get_series_uid_from_blob_iterator(index_iter), series_uid)
-        self.assertEqual(_get_series_uid_from_blob_iterator(thumbnail_iter), series_uid)
-        self.assertEqual(_get_series_uid_from_blob_iterator(lock_iter), series_uid)
-
-        # expect a ValueError if the iterator has junk
-        with self.assertRaises(ValueError):
-            _get_series_uid_from_blob_iterator(junk_iter)
-
-        # expect a ValueError if the iterator is empty
-        with self.assertRaises(ValueError):
-            _get_series_uid_from_blob_iterator(iter([]))
-
-    def test_get_study(self):
-        """
-        Test retrieving the metadata for a study
-        """
-        study_uri = os.path.join(
-            self.datastore_path,
-            "studies",
-            "1.2.826.0.1.3680043.8.498.18783474219392509401504861043428417882",
-            "metadata",
-        )
-        result = handle_request(study_uri, self.client)
-        # we expect a dictionary of metadata
-        self.assertIsInstance(result, dict)
-        # expect all study level tags to be present, and not None
-        for tag in STUDY_LEVEL_TAGS:
-            self.assertIsNotNone(result[tag]["Value"][0])
-
-    def test_get_series(self):
-        """
-        Test retrieving the metadata for a series
-        """
-        series_uri = os.path.join(
-            self.datastore_path,
-            "studies",
-            "1.2.826.0.1.3680043.8.498.18783474219392509401504861043428417882",
-            "series",
-            "1.2.826.0.1.3680043.8.498.89840699185761593370876698622882853150",
-            "metadata",
-        )
-        result = handle_request(series_uri, self.client)
-        # we expect a list of instance metadata dictionaries
-        self.assertIsInstance(result, list)
-        # there happen to be 82 instances in this series
-        self.assertEqual(len(result), 82)
-        # check something in each instance (e.g. series uid)
-        series_uid = result[0]["0020000D"]["Value"][0]
-        self.assertTrue(is_valid_uid(series_uid))
-        for instance in result:
-            self.assertEqual(instance["0020000D"]["Value"][0], series_uid)
-
-    def test_get_instance(self):
-        """
-        Test retrieving the metadata for an instance
-        """
-        instance_uri = os.path.join(
-            self.datastore_path,
-            "studies",
-            "1.2.826.0.1.3680043.8.498.18783474219392509401504861043428417882",
-            "series",
-            "1.2.826.0.1.3680043.8.498.89840699185761593370876698622882853150",
-            "instances",
-            "1.2.826.0.1.3680043.8.498.10368404844741579486264078308290534273",
-            "metadata",
-        )
-        result = handle_request(instance_uri, self.client)
-        # we expect a dictionary of metadata
-        self.assertIsInstance(result, dict)
-        # check something in the metadata (e.g. series uid)
-        series_uid = result["0020000D"]["Value"][0]
-        self.assertTrue(is_valid_uid(series_uid))
-
-    def test_get_single_frame(self):
-        """
-        Test retrieving a single frame from an instance
-        """
-        frame_uri = os.path.join(
-            self.datastore_path,
-            "studies",
-            "1.2.826.0.1.3680043.8.498.18783474219392509401504861043428417882",
-            "series",
-            "1.2.826.0.1.3680043.8.498.89840699185761593370876698622882853150",
-            "instances",
-            "1.2.826.0.1.3680043.8.498.10368404844741579486264078308290534273",
-            "frames",
-            "1",
-        )
-        result = handle_request(frame_uri, self.client)
-        # we expect a non-empty list of bytes
-        self.assertIsInstance(result, list)
-        self.assertEqual(len(result), 1)
-        self.assertIsInstance(result[0], bytes)
-        self.assertTrue(len(result[0]) > 0)
-
-    def test_get_too_many_frames_errors(self):
-        """
-        Test retrieving multiple frames from an instance with only one frame raises an error
-        """
-        frame_uri = os.path.join(
-            self.datastore_path,
-            "studies",
-            "1.2.826.0.1.3680043.8.498.18783474219392509401504861043428417882",
-            "series",
-            "1.2.826.0.1.3680043.8.498.89840699185761593370876698622882853150",
-            "instances",
-            "1.2.826.0.1.3680043.8.498.10368404844741579486264078308290534273",
-            "frames",
-            "1,2",
-        )
-        with self.assertRaises(AssertionError):
-            handle_request(frame_uri, self.client)
-
-    def test_non_metadata_requests_raise_error(self):
-        """
-        Test that non-metadata requests raise an error
-        """
-        request_uri = os.path.join(
-            self.datastore_path,
-            "studies",
-            "1.2.826.0.1.3680043.8.498.18783474219392509401504861043428417882",
-            "series",
-            "1.2.826.0.1.3680043.8.498.89840699185761593370876698622882853150",
-            "instances",
-            "1.2.826.0.1.3680043.8.498.10368404844741579486264078308290534273",
-        )
-        with self.assertRaises(AssertionError):
-            handle_request(request_uri, self.client)
+DICOMWEB_DATASTORE_PATH = "gs://siskin-172863-pacs/v1.0/dicomweb"
 
 
-if __name__ == "__main__":
-    unittest.main()
+@pytest.fixture(scope="module")
+def dicomweb_datastore_path() -> str:
+    return DICOMWEB_DATASTORE_PATH
+
+
+def test_get_series_uid_from_blob_iterator(dicomweb_datastore_path: str):
+    """
+    Test that the series uid can be extracted from all standard COD blobs
+    """
+    # simulate iterators returning every possible blob first
+    series_uid = "1.2.826.0.1.3680043.8.498.89840699185761593370876698622882853150"
+    series_uri = os.path.join(
+        dicomweb_datastore_path,
+        "studies",
+        "1.2.826.0.1.3680043.8.498.18783474219392509401504861043428417882",
+        "series",
+        series_uid,
+    )
+    tar_iter = iter([storage.Blob.from_string(f"{series_uri}.tar")])
+    metadata_iter = iter(
+        [storage.Blob.from_string(os.path.join(series_uri, "metadata.json"))]
+    )
+    index_iter = iter(
+        [storage.Blob.from_string(os.path.join(series_uri, "index.sqlite"))]
+    )
+    thumbnail_iter = iter(
+        [storage.Blob.from_string(os.path.join(series_uri, "thumbnail.mp4"))]
+    )
+    lock_iter = iter(
+        [storage.Blob.from_string(os.path.join(series_uri, ".gradient.lock"))]
+    )
+    junk_iter = iter([storage.Blob.from_string(f"gs://this/is/a/junk/blob")])
+
+    # make sure that no matter which blob the iterator returns, the series uid is extracted correctly
+    assert _get_series_uid_from_blob_iterator(tar_iter) == series_uid
+    assert _get_series_uid_from_blob_iterator(metadata_iter) == series_uid
+    assert _get_series_uid_from_blob_iterator(index_iter) == series_uid
+    assert _get_series_uid_from_blob_iterator(thumbnail_iter) == series_uid
+    assert _get_series_uid_from_blob_iterator(lock_iter) == series_uid
+
+    # expect a ValueError if the iterator has junk
+    with pytest.raises(ValueError):
+        _get_series_uid_from_blob_iterator(junk_iter)
+
+    # expect a ValueError if the iterator is empty
+    with pytest.raises(ValueError):
+        _get_series_uid_from_blob_iterator(iter([]))
+
+
+def test_get_study(gcs_client: storage.Client, dicomweb_datastore_path: str):
+    """
+    Test retrieving the metadata for a study
+    """
+    study_uri = os.path.join(
+        dicomweb_datastore_path,
+        "studies",
+        "1.2.826.0.1.3680043.8.498.18783474219392509401504861043428417882",
+        "metadata",
+    )
+    result = handle_request(study_uri, gcs_client)
+    # we expect a dictionary of metadata
+    assert isinstance(result, dict)
+    # expect all study level tags to be present, and not None
+    for tag in STUDY_LEVEL_TAGS:
+        assert result[tag]["Value"][0] is not None
+
+
+def test_get_series(gcs_client: storage.Client, dicomweb_datastore_path: str):
+    """
+    Test retrieving the metadata for a series
+    """
+    series_uri = os.path.join(
+        dicomweb_datastore_path,
+        "studies",
+        "1.2.826.0.1.3680043.8.498.18783474219392509401504861043428417882",
+        "series",
+        "1.2.826.0.1.3680043.8.498.89840699185761593370876698622882853150",
+        "metadata",
+    )
+    result = handle_request(series_uri, gcs_client)
+    # we expect a list of instance metadata dictionaries
+    assert isinstance(result, list)
+    # there happen to be 82 instances in this series
+    assert len(result) == 82
+    # check something in each instance (e.g. series uid)
+    series_uid = result[0]["0020000D"]["Value"][0]
+    assert is_valid_uid(series_uid)
+    for instance in result:
+        assert instance["0020000D"]["Value"][0] == series_uid
+
+
+def test_get_instance(gcs_client: storage.Client, dicomweb_datastore_path: str):
+    """
+    Test retrieving the metadata for an instance
+    """
+    instance_uri = os.path.join(
+        dicomweb_datastore_path,
+        "studies",
+        "1.2.826.0.1.3680043.8.498.18783474219392509401504861043428417882",
+        "series",
+        "1.2.826.0.1.3680043.8.498.89840699185761593370876698622882853150",
+        "instances",
+        "1.2.826.0.1.3680043.8.498.10368404844741579486264078308290534273",
+        "metadata",
+    )
+    result = handle_request(instance_uri, gcs_client)
+    # we expect a dictionary of metadata
+    assert isinstance(result, dict)
+    # check something in the metadata (e.g. series uid)
+    series_uid = result["0020000D"]["Value"][0]
+    assert is_valid_uid(series_uid)
+
+
+def test_get_single_frame(gcs_client: storage.Client, dicomweb_datastore_path: str):
+    """
+    Test retrieving a single frame from an instance
+    """
+    frame_uri = os.path.join(
+        dicomweb_datastore_path,
+        "studies",
+        "1.2.826.0.1.3680043.8.498.18783474219392509401504861043428417882",
+        "series",
+        "1.2.826.0.1.3680043.8.498.89840699185761593370876698622882853150",
+        "instances",
+        "1.2.826.0.1.3680043.8.498.10368404844741579486264078308290534273",
+        "frames",
+        "1",
+    )
+    result = handle_request(frame_uri, gcs_client)
+    # we expect a non-empty list of bytes
+    assert isinstance(result, list)
+    assert len(result) == 1
+    assert isinstance(result[0], bytes)
+    assert len(result[0]) > 0
+
+
+def test_get_too_many_frames_errors(
+    gcs_client: storage.Client, dicomweb_datastore_path: str
+):
+    """
+    Test retrieving multiple frames from an instance with only one frame raises an error
+    """
+    frame_uri = os.path.join(
+        dicomweb_datastore_path,
+        "studies",
+        "1.2.826.0.1.3680043.8.498.18783474219392509401504861043428417882",
+        "series",
+        "1.2.826.0.1.3680043.8.498.89840699185761593370876698622882853150",
+        "instances",
+        "1.2.826.0.1.3680043.8.498.10368404844741579486264078308290534273",
+        "frames",
+        "1,2",
+    )
+    with pytest.raises(AssertionError):
+        handle_request(frame_uri, gcs_client)
+
+
+def test_non_metadata_requests_raise_error(
+    gcs_client: storage.Client, dicomweb_datastore_path: str
+):
+    """
+    Test that non-metadata requests raise an error
+    """
+    request_uri = os.path.join(
+        dicomweb_datastore_path,
+        "studies",
+        "1.2.826.0.1.3680043.8.498.18783474219392509401504861043428417882",
+        "series",
+        "1.2.826.0.1.3680043.8.498.89840699185761593370876698622882853150",
+        "instances",
+        "1.2.826.0.1.3680043.8.498.10368404844741579486264078308290534273",
+    )
+    with pytest.raises(AssertionError):
+        handle_request(request_uri, gcs_client)

--- a/cloud_optimized_dicom/tests/test_error_log.py
+++ b/cloud_optimized_dicom/tests/test_error_log.py
@@ -1,107 +1,101 @@
 import os
 import traceback
-import unittest
 
-from google.api_core.client_options import ClientOptions
+import pytest
 from google.cloud import storage
 
 from cloud_optimized_dicom.cod_object import CODObject
 from cloud_optimized_dicom.errors import ErrorLogExistsError
 from cloud_optimized_dicom.utils import delete_uploaded_blobs
 
+ERROR_LOG_DATASTORE_PATH = "gs://siskin-172863-temp/cod_error_log_tests/dicomweb"
+ERROR_LOG_STUDY_UID = "1.2.3.4.5.6.7.8.9.10"
+ERROR_LOG_SERIES_UID = "1.2.3.4.5.6.7.8.9.10"
 
-@unittest.skipIf("SKIP_NETWORK_TESTS" in os.environ, reason="network tests disabled")
-class TestErrorLog(unittest.TestCase):
-    # python -m unittest components.cloud_optimized_dicom.tests.test_error_log.TestErrorLog
+pytestmark = pytest.mark.skipif(
+    "SKIP_NETWORK_TESTS" in os.environ, reason="network tests disabled"
+)
 
-    @classmethod
-    def setUpClass(cls):
-        cls.client = storage.Client(
-            project="gradient-pacs-siskin-172863",
-            client_options=ClientOptions(
-                quota_project_id="gradient-pacs-siskin-172863"
-            ),
-        )
-        cls.datastore_path = "gs://siskin-172863-temp/cod_error_log_tests/dicomweb"
-        cls.study_uid = "1.2.3.4.5.6.7.8.9.10"
-        cls.series_uid = "1.2.3.4.5.6.7.8.9.10"
 
-    def setUp(self):
-        delete_uploaded_blobs(self.client, [self.datastore_path])
+@pytest.fixture
+def error_log_datastore_path(gcs_client: storage.Client) -> str:
+    delete_uploaded_blobs(gcs_client, [ERROR_LOG_DATASTORE_PATH])
+    return ERROR_LOG_DATASTORE_PATH
 
-    def test_error_log_upload(self):
-        try:
-            with CODObject(
-                datastore_path=self.datastore_path,
-                client=self.client,
-                study_uid=self.study_uid,
-                series_uid=self.series_uid,
-                mode="w",
-            ) as cod_obj:
-                # simulate doing something with the CODObjet and causing an error
-                raise Exception("test error")
-        except Exception:
-            cod_obj.upload_error_log(traceback.format_exc())
 
-        # error log should exist
-        error_blob = storage.Blob.from_string(cod_obj.error_log_uri, client=self.client)
-        self.assertTrue(error_blob.exists())
-        # error log should contain the error message
-        self.assertIn("test error", error_blob.download_as_bytes().decode("utf-8"))
-        # lock should have been released (non-sync exception doesn't leave hanging lock)
-        # the error log alone is sufficient to brick the COD
-        self.assertFalse(cod_obj._locker.get_lock_blob().exists())
-
-    def test_error_existence_bricks_cod_object_initialization(self):
-        """Test that the error log bricks CODObject initialization"""
-        # Create the error log
+def test_error_log_upload(gcs_client: storage.Client, error_log_datastore_path: str):
+    try:
         with CODObject(
-            datastore_path=self.datastore_path,
-            client=self.client,
-            study_uid=self.study_uid,
-            series_uid=self.series_uid,
+            datastore_path=error_log_datastore_path,
+            client=gcs_client,
+            study_uid=ERROR_LOG_STUDY_UID,
+            series_uid=ERROR_LOG_SERIES_UID,
             mode="w",
         ) as cod_obj:
-            cod_obj.upload_error_log("test error")
+            # simulate doing something with the CODObjet and causing an error
+            raise Exception("test error")
+    except Exception:
+        cod_obj.upload_error_log(traceback.format_exc())
 
-        # Try to initialize the CODObject again and expect error
-        with self.assertRaises(ErrorLogExistsError):
-            with CODObject(
-                datastore_path=self.datastore_path,
-                client=self.client,
-                study_uid=self.study_uid,
-                series_uid=self.series_uid,
-                mode="w",
-            ) as cod_obj:
-                pass
+    # error log should exist
+    error_blob = storage.Blob.from_string(cod_obj.error_log_uri, client=gcs_client)
+    assert error_blob.exists()
+    # error log should contain the error message
+    assert "test error" in error_blob.download_as_bytes().decode("utf-8")
+    # lock should have been released (non-sync exception doesn't leave hanging lock)
+    # the error log alone is sufficient to brick the COD
+    assert not cod_obj._locker.get_lock_blob().exists()
 
-    def test_error_log_override(self):
-        """Test that the error log can be overridden"""
-        # Create the error log
+
+def test_error_existence_bricks_cod_object_initialization(
+    gcs_client: storage.Client, error_log_datastore_path: str
+):
+    """Test that the error log bricks CODObject initialization"""
+    # Create the error log
+    with CODObject(
+        datastore_path=error_log_datastore_path,
+        client=gcs_client,
+        study_uid=ERROR_LOG_STUDY_UID,
+        series_uid=ERROR_LOG_SERIES_UID,
+        mode="w",
+    ) as cod_obj:
+        cod_obj.upload_error_log("test error")
+
+    # Try to initialize the CODObject again and expect error
+    with pytest.raises(ErrorLogExistsError):
         with CODObject(
-            datastore_path=self.datastore_path,
-            client=self.client,
-            study_uid=self.study_uid,
-            series_uid=self.series_uid,
+            datastore_path=error_log_datastore_path,
+            client=gcs_client,
+            study_uid=ERROR_LOG_STUDY_UID,
+            series_uid=ERROR_LOG_SERIES_UID,
             mode="w",
-        ) as cod_obj:
-            cod_obj.upload_error_log("test error")
-
-        # override the error log
-        with CODObject(
-            datastore_path=self.datastore_path,
-            client=self.client,
-            study_uid=self.study_uid,
-            series_uid=self.series_uid,
-            mode="w",
-            override_errors=True,
         ) as cod_obj:
             pass
 
-        self.assertFalse(
-            storage.Blob.from_string(cod_obj.error_log_uri, client=self.client).exists()
-        )
 
+def test_error_log_override(gcs_client: storage.Client, error_log_datastore_path: str):
+    """Test that the error log can be overridden"""
+    # Create the error log
+    with CODObject(
+        datastore_path=error_log_datastore_path,
+        client=gcs_client,
+        study_uid=ERROR_LOG_STUDY_UID,
+        series_uid=ERROR_LOG_SERIES_UID,
+        mode="w",
+    ) as cod_obj:
+        cod_obj.upload_error_log("test error")
 
-if __name__ == "__main__":
-    unittest.main()
+    # override the error log
+    with CODObject(
+        datastore_path=error_log_datastore_path,
+        client=gcs_client,
+        study_uid=ERROR_LOG_STUDY_UID,
+        series_uid=ERROR_LOG_SERIES_UID,
+        mode="w",
+        override_errors=True,
+    ) as cod_obj:
+        pass
+
+    assert not storage.Blob.from_string(
+        cod_obj.error_log_uri, client=gcs_client
+    ).exists()

--- a/cloud_optimized_dicom/tests/test_hashed_uids.py
+++ b/cloud_optimized_dicom/tests/test_hashed_uids.py
@@ -1,9 +1,7 @@
-import os
-import unittest
 from tempfile import NamedTemporaryFile
 
 import pydicom3
-from google.api_core.client_options import ClientOptions
+import pytest
 from google.cloud import storage
 
 from cloud_optimized_dicom.cod_object import CODObject
@@ -23,182 +21,180 @@ def example_hash_function(uid: str) -> str:
     return ".".join(split_uid)
 
 
-class TestDeid(unittest.TestCase):
+def test_instance_hashing():
+    """Test the cod_object hash_func_provided property"""
+    instance = Instance(
+        dicom_uri="gs://bucket/path/to/file.dcm",
+        hints=Hints(
+            instance_uid="1.2.3.4",
+            series_uid="1.2.3.4",
+            study_uid="1.2.3.4",
+        ),
+        uid_hash_func=example_hash_function,
+    )
+    assert instance.uid_hash_func
+    assert instance.instance_uid(trust_hints_if_available=True) == "1.2.3.4"
+    assert instance.hashed_instance_uid(trust_hints_if_available=True) == "1.2.3.5"
+    assert instance.hashed_series_uid(trust_hints_if_available=True) == "1.2.3.5"
+    assert instance.hashed_study_uid(trust_hints_if_available=True) == "1.2.3.5"
 
-    @classmethod
-    def setUpClass(cls):
-        cls.test_data_dir = os.path.join(os.path.dirname(__file__), "test_data")
-        cls.test_instance_uid = "1.2.276.0.50.192168001092.11156604.14547392.313"
-        cls.test_series_uid = "1.2.276.0.50.192168001092.11156604.14547392.303"
-        cls.test_study_uid = "1.2.276.0.50.192168001092.11156604.14547392.4"
-        cls.local_instance_path = os.path.join(cls.test_data_dir, "monochrome2.dcm")
-        cls.client = storage.Client(
-            project="gradient-pacs-siskin-172863",
-            client_options=ClientOptions(
-                quota_project_id="gradient-pacs-siskin-172863"
-            ),
-        )
-        cls.datastore_path = "gs://siskin-172863-temp/cod_tests/dicomweb"
 
-    def test_instance_hashing(self):
-        """Test the cod_object hash_func_provided property"""
-        instance = Instance(
-            dicom_uri="gs://bucket/path/to/file.dcm",
-            hints=Hints(
-                instance_uid="1.2.3.4",
-                series_uid="1.2.3.4",
-                study_uid="1.2.3.4",
-            ),
-            uid_hash_func=example_hash_function,
-        )
-        self.assertTrue(instance.uid_hash_func)
-        self.assertEqual(
-            instance.instance_uid(trust_hints_if_available=True), "1.2.3.4"
-        )
-        self.assertEqual(
-            instance.hashed_instance_uid(trust_hints_if_available=True), "1.2.3.5"
-        )
-        self.assertEqual(
-            instance.hashed_series_uid(trust_hints_if_available=True), "1.2.3.5"
-        )
-        self.assertEqual(
-            instance.hashed_study_uid(trust_hints_if_available=True), "1.2.3.5"
-        )
+def test_instance_no_hash_func():
+    """Test that trying to get a hashed uid without a hash function raises an error"""
+    instance = Instance(
+        dicom_uri="gs://bucket/path/to/file.dcm",
+        hints=Hints(instance_uid="1.2.3.4"),
+    )
+    assert not instance.uid_hash_func
+    with pytest.raises(ValueError):
+        instance.hashed_instance_uid(trust_hints_if_available=True)
+    with pytest.raises(ValueError):
+        instance.hashed_series_uid(trust_hints_if_available=True)
+    with pytest.raises(ValueError):
+        instance.hashed_study_uid(trust_hints_if_available=True)
 
-    def test_instance_no_hash_func(self):
-        """Test that trying to get a hashed uid without a hash function raises an error"""
-        instance = Instance(
-            dicom_uri="gs://bucket/path/to/file.dcm",
-            hints=Hints(instance_uid="1.2.3.4"),
-        )
-        self.assertFalse(instance.uid_hash_func)
-        with self.assertRaises(ValueError):
-            instance.hashed_instance_uid(trust_hints_if_available=True)
-        with self.assertRaises(ValueError):
-            instance.hashed_series_uid(trust_hints_if_available=True)
-        with self.assertRaises(ValueError):
-            instance.hashed_study_uid(trust_hints_if_available=True)
 
-    def test_instance_belongs_to_cod_object(self):
-        """Test validation of instance belonging to a cod_object"""
-        # create cod_object with original uids
-        cod_object = CODObject(
-            datastore_path=self.datastore_path,
-            client=self.client,
-            study_uid=self.test_study_uid,
-            series_uid=self.test_series_uid,
-            mode="w",
-            sync_on_exit=False,
-        )
-        # create instance with original uids
-        instance = Instance(
-            dicom_uri=self.local_instance_path,
-            hints=Hints(
-                instance_uid=self.test_instance_uid,
-                series_uid=self.test_series_uid,
-                study_uid=self.test_study_uid,
-            ),
-        )
-        # with neither cod_object nor instance having a uid hash function, the instance belongs to the cod_object
-        self.assertTrue(cod_object.assert_instance_belongs_to_cod_object(instance))
-        # if instead the instance had a uid hash function, it would not belong to the cod_object
-        instance.uid_hash_func = example_hash_function
-        with self.assertRaises(InstanceValidationError):
-            cod_object.assert_instance_belongs_to_cod_object(instance)
-        # if instead the cod_object had hashed_uids=True, and the instance did NOT have a uid hash function, it would not belong to the cod_object
-        cod_object.hashed_uids = True
-        instance.uid_hash_func = None
-        with self.assertRaises(InstanceValidationError):
-            cod_object.assert_instance_belongs_to_cod_object(instance)
-        # if both had hashing, but the cod object was created with unhashed uids, it would not belong
-        instance.uid_hash_func = example_hash_function
-        with self.assertRaises(InstanceValidationError):
-            cod_object.assert_instance_belongs_to_cod_object(instance)
-        # finally, if the cod_object had the hashed uids, and the instance had the hashed uids, the instance would belong
-        cod_object.study_uid = example_hash_function(self.test_study_uid)
-        cod_object.series_uid = example_hash_function(self.test_series_uid)
+def test_instance_belongs_to_cod_object(
+    gcs_client: storage.Client,
+    datastore_path: str,
+    local_instance_path: str,
+    test_study_uid: str,
+    test_series_uid: str,
+    test_instance_uid: str,
+):
+    """Test validation of instance belonging to a cod_object"""
+    # create cod_object with original uids
+    cod_object = CODObject(
+        datastore_path=datastore_path,
+        client=gcs_client,
+        study_uid=test_study_uid,
+        series_uid=test_series_uid,
+        mode="w",
+        sync_on_exit=False,
+    )
+    # create instance with original uids
+    instance = Instance(
+        dicom_uri=local_instance_path,
+        hints=Hints(
+            instance_uid=test_instance_uid,
+            series_uid=test_series_uid,
+            study_uid=test_study_uid,
+        ),
+    )
+    # with neither cod_object nor instance having a uid hash function, the instance belongs to the cod_object
+    assert cod_object.assert_instance_belongs_to_cod_object(instance)
+    # if instead the instance had a uid hash function, it would not belong to the cod_object
+    instance.uid_hash_func = example_hash_function
+    with pytest.raises(InstanceValidationError):
+        cod_object.assert_instance_belongs_to_cod_object(instance)
+    # if instead the cod_object had hashed_uids=True, and the instance did NOT have a uid hash function, it would not belong to the cod_object
+    cod_object.hashed_uids = True
+    instance.uid_hash_func = None
+    with pytest.raises(InstanceValidationError):
+        cod_object.assert_instance_belongs_to_cod_object(instance)
+    # if both had hashing, but the cod object was created with unhashed uids, it would not belong
+    instance.uid_hash_func = example_hash_function
+    with pytest.raises(InstanceValidationError):
+        cod_object.assert_instance_belongs_to_cod_object(instance)
+    # finally, if the cod_object had the hashed uids, and the instance had the hashed uids, the instance would belong
+    cod_object.study_uid = example_hash_function(test_study_uid)
+    cod_object.series_uid = example_hash_function(test_series_uid)
+    cod_object.assert_instance_belongs_to_cod_object(instance)
+
+
+def test_accidental_double_hash(
+    gcs_client: storage.Client,
+    datastore_path: str,
+    local_instance_path: str,
+    test_study_uid: str,
+    test_series_uid: str,
+):
+    """Test that instances do not belong if cod_object accidentally hashed uids twice"""
+    hashed_study_uid = example_hash_function(test_study_uid)
+    hashed_series_uid = example_hash_function(test_series_uid)
+    twice_hashed_study_uid = example_hash_function(hashed_study_uid)
+    twice_hashed_series_uid = example_hash_function(hashed_series_uid)
+    cod_object = CODObject(
+        datastore_path=datastore_path,
+        client=gcs_client,
+        study_uid=twice_hashed_study_uid,
+        series_uid=twice_hashed_series_uid,
+        mode="w",
+        sync_on_exit=False,
+        hashed_uids=True,
+    )
+    instance = Instance(dicom_uri=local_instance_path)
+    with pytest.raises(InstanceValidationError):
         cod_object.assert_instance_belongs_to_cod_object(instance)
 
-    def test_accidental_double_hash(self):
-        """Test that instances do not belong if cod_object accidentally hashed uids twice"""
-        hashed_study_uid = example_hash_function(self.test_study_uid)
-        hashed_series_uid = example_hash_function(self.test_series_uid)
-        twice_hashed_study_uid = example_hash_function(hashed_study_uid)
-        twice_hashed_series_uid = example_hash_function(hashed_series_uid)
-        cod_object = CODObject(
-            datastore_path=self.datastore_path,
-            client=self.client,
-            study_uid=twice_hashed_study_uid,
-            series_uid=twice_hashed_series_uid,
-            mode="w",
-            sync_on_exit=False,
-            hashed_uids=True,
-        )
-        instance = Instance(dicom_uri=self.local_instance_path)
-        with self.assertRaises(InstanceValidationError):
-            cod_object.assert_instance_belongs_to_cod_object(instance)
 
-    def test_cod_obj_metadata_hashed_uids(self):
-        """Test that cod_obj metadata hashed_uids property is correctly set"""
-        # append a DEID instance to a cod object
-        cod_object = CODObject(
-            datastore_path=self.datastore_path,
-            client=self.client,
-            study_uid=example_hash_function(self.test_study_uid),
-            series_uid=example_hash_function(self.test_series_uid),
-            mode="w",
-            sync_on_exit=False,
-            hashed_uids=True,
-        )
-        instance = Instance(
-            dicom_uri=self.local_instance_path, uid_hash_func=example_hash_function
-        )
-        append_result = cod_object.append([instance])
-        # verify append success
-        self.assertEqual(append_result.new[0], instance)
-        metadata_dict = cod_object.get_metadata().to_dict()
-        # because the cod_object has hashed_uids=True, the metadata should have deid_uids
-        self.assertEqual(
-            metadata_dict["deid_study_uid"], example_hash_function(self.test_study_uid)
-        )
-        self.assertEqual(
-            metadata_dict["deid_series_uid"],
-            example_hash_function(self.test_series_uid),
-        )
-        # the original uids should not be present in the metadata
-        self.assertNotIn("study_uid", metadata_dict)
-        self.assertNotIn("series_uid", metadata_dict)
-        # the metadata should contain the single instance we appended
-        instances_dict = metadata_dict["cod"]["instances"]
-        self.assertEqual(len(instances_dict), 1)
-        # this instance should have the hashed UID
-        self.assertIn(instance.hashed_instance_uid(), instances_dict)
-        # the original UID should not be present
-        self.assertNotIn(instance.instance_uid(), instances_dict)
+def test_cod_obj_metadata_hashed_uids(
+    gcs_client: storage.Client,
+    datastore_path: str,
+    local_instance_path: str,
+    test_study_uid: str,
+    test_series_uid: str,
+):
+    """Test that cod_obj metadata hashed_uids property is correctly set"""
+    # append a DEID instance to a cod object
+    cod_object = CODObject(
+        datastore_path=datastore_path,
+        client=gcs_client,
+        study_uid=example_hash_function(test_study_uid),
+        series_uid=example_hash_function(test_series_uid),
+        mode="w",
+        sync_on_exit=False,
+        hashed_uids=True,
+    )
+    instance = Instance(
+        dicom_uri=local_instance_path, uid_hash_func=example_hash_function
+    )
+    append_result = cod_object.append([instance])
+    # verify append success
+    assert append_result.new[0] == instance
+    metadata_dict = cod_object.get_metadata().to_dict()
+    # because the cod_object has hashed_uids=True, the metadata should have deid_uids
+    assert metadata_dict["deid_study_uid"] == example_hash_function(test_study_uid)
+    assert metadata_dict["deid_series_uid"] == example_hash_function(test_series_uid)
+    # the original uids should not be present in the metadata
+    assert "study_uid" not in metadata_dict
+    assert "series_uid" not in metadata_dict
+    # the metadata should contain the single instance we appended
+    instances_dict = metadata_dict["cod"]["instances"]
+    assert len(instances_dict) == 1
+    # this instance should have the hashed UID
+    assert instance.hashed_instance_uid() in instances_dict
+    # the original UID should not be present
+    assert instance.instance_uid() not in instances_dict
 
-    def test_append_diff_hash_dupe_with_hashed_uids(self):
-        """Test that a diff hash dupe is detected with hashed uids"""
-        cod_object = CODObject(
-            datastore_path=self.datastore_path,
-            client=self.client,
-            study_uid=example_hash_function(self.test_study_uid),
-            series_uid=example_hash_function(self.test_series_uid),
-            mode="w",
-            sync_on_exit=False,
-            hashed_uids=True,
-        )
-        instance = Instance(
-            dicom_uri=self.local_instance_path, uid_hash_func=example_hash_function
-        )
-        append_result = cod_object.append([instance])
-        self.assertEqual(append_result.new[0], instance)
-        # make a diff hash dupe
-        with NamedTemporaryFile(suffix=".dcm") as f:
-            with pydicom3.dcmread(self.local_instance_path) as ds:
-                ds.add_new((0x1234, 0x5678), "DS", "12345678")
-                ds.save_as(f.name)
-            diff_hash_dupe = Instance(
-                dicom_uri=f.name, uid_hash_func=example_hash_function
-            )
-            append_result = cod_object.append([diff_hash_dupe])
-            self.assertEqual(append_result.conflict[0], diff_hash_dupe)
+
+def test_append_diff_hash_dupe_with_hashed_uids(
+    gcs_client: storage.Client,
+    datastore_path: str,
+    local_instance_path: str,
+    test_study_uid: str,
+    test_series_uid: str,
+):
+    """Test that a diff hash dupe is detected with hashed uids"""
+    cod_object = CODObject(
+        datastore_path=datastore_path,
+        client=gcs_client,
+        study_uid=example_hash_function(test_study_uid),
+        series_uid=example_hash_function(test_series_uid),
+        mode="w",
+        sync_on_exit=False,
+        hashed_uids=True,
+    )
+    instance = Instance(
+        dicom_uri=local_instance_path, uid_hash_func=example_hash_function
+    )
+    append_result = cod_object.append([instance])
+    assert append_result.new[0] == instance
+    # make a diff hash dupe
+    with NamedTemporaryFile(suffix=".dcm") as f:
+        with pydicom3.dcmread(local_instance_path) as ds:
+            ds.add_new((0x1234, 0x5678), "DS", "12345678")
+            ds.save_as(f.name)
+        diff_hash_dupe = Instance(dicom_uri=f.name, uid_hash_func=example_hash_function)
+        append_result = cod_object.append([diff_hash_dupe])
+        assert append_result.conflict[0] == diff_hash_dupe

--- a/cloud_optimized_dicom/tests/test_hints.py
+++ b/cloud_optimized_dicom/tests/test_hints.py
@@ -1,56 +1,56 @@
 import os
-import unittest
+
+import pytest
 
 from cloud_optimized_dicom.errors import HintMismatchError
 from cloud_optimized_dicom.hints import Hints
 from cloud_optimized_dicom.instance import Instance
 
 
-class TestHints(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        cls.test_data_dir = os.path.join(os.path.dirname(__file__), "test_data")
+def test_empty_hints(test_data_dir: str):
+    hints = Hints()
+    instance = Instance(
+        dicom_uri=os.path.join(test_data_dir, "monochrome2.dcm"), hints=hints
+    )
+    assert instance.validate()
 
-    def test_empty_hints(self):
-        hints = Hints()
-        instance = Instance(
-            dicom_uri=os.path.join(self.test_data_dir, "monochrome2.dcm"), hints=hints
-        )
-        self.assertTrue(instance.validate())
 
-    def test_good_hints(self):
-        hints = Hints(
-            instance_uid="1.2.276.0.50.192168001092.11156604.14547392.313",
-            series_uid="1.2.276.0.50.192168001092.11156604.14547392.303",
-            study_uid="1.2.276.0.50.192168001092.11156604.14547392.4",
-            size=527800,
-            crc32c="uEaR6w==",
-        )
-        instance = Instance(
-            dicom_uri=os.path.join(self.test_data_dir, "monochrome2.dcm"), hints=hints
-        )
-        self.assertTrue(instance.validate())
+def test_good_hints(test_data_dir: str):
+    hints = Hints(
+        instance_uid="1.2.276.0.50.192168001092.11156604.14547392.313",
+        series_uid="1.2.276.0.50.192168001092.11156604.14547392.303",
+        study_uid="1.2.276.0.50.192168001092.11156604.14547392.4",
+        size=527800,
+        crc32c="uEaR6w==",
+    )
+    instance = Instance(
+        dicom_uri=os.path.join(test_data_dir, "monochrome2.dcm"), hints=hints
+    )
+    assert instance.validate()
 
-    def test_bad_uid(self):
-        hints = Hints(instance_uid="BAD_UID")
-        instance = Instance(
-            dicom_uri=os.path.join(self.test_data_dir, "monochrome2.dcm"), hints=hints
-        )
-        with self.assertRaises(HintMismatchError):
-            instance.validate()
 
-    def test_bad_size(self):
-        hints = Hints(size=1000)
-        instance = Instance(
-            dicom_uri=os.path.join(self.test_data_dir, "monochrome2.dcm"), hints=hints
-        )
-        with self.assertRaises(HintMismatchError):
-            instance.validate()
+def test_bad_uid(test_data_dir: str):
+    hints = Hints(instance_uid="BAD_UID")
+    instance = Instance(
+        dicom_uri=os.path.join(test_data_dir, "monochrome2.dcm"), hints=hints
+    )
+    with pytest.raises(HintMismatchError):
+        instance.validate()
 
-    def test_bad_crc32c(self):
-        hints = Hints(crc32c="BAD_CRC32C")
-        instance = Instance(
-            dicom_uri=os.path.join(self.test_data_dir, "monochrome2.dcm"), hints=hints
-        )
-        with self.assertRaises(HintMismatchError):
-            instance.validate()
+
+def test_bad_size(test_data_dir: str):
+    hints = Hints(size=1000)
+    instance = Instance(
+        dicom_uri=os.path.join(test_data_dir, "monochrome2.dcm"), hints=hints
+    )
+    with pytest.raises(HintMismatchError):
+        instance.validate()
+
+
+def test_bad_crc32c(test_data_dir: str):
+    hints = Hints(crc32c="BAD_CRC32C")
+    instance = Instance(
+        dicom_uri=os.path.join(test_data_dir, "monochrome2.dcm"), hints=hints
+    )
+    with pytest.raises(HintMismatchError):
+        instance.validate()

--- a/cloud_optimized_dicom/tests/test_instance.py
+++ b/cloud_optimized_dicom/tests/test_instance.py
@@ -1,186 +1,174 @@
 import os
 import tarfile
 import tempfile
-import unittest
 
 import pydicom3
+import pytest
 
 from cloud_optimized_dicom.instance import Instance
 from cloud_optimized_dicom.utils import is_remote
 
+REMOTE_DICOM_URI = "https://code.oak-tree.tech/oak-tree/medical-imaging/dcmjs/-/raw/master/test/sample-dicom.dcm?ref_type=heads&inline=false"
 
-class TestInstance(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        cls.test_data_dir = os.path.join(os.path.dirname(__file__), "test_data")
-        cls.remote_dicom_uri = "https://code.oak-tree.tech/oak-tree/medical-imaging/dcmjs/-/raw/master/test/sample-dicom.dcm?ref_type=heads&inline=false"
-        cls.test_instance_uid = "1.2.276.0.50.192168001092.11156604.14547392.313"
-        cls.local_instance_path = os.path.join(cls.test_data_dir, "monochrome2.dcm")
 
-    def test_remote_detection(self):
-        self.assertTrue(is_remote("s3://bucket/path/to/file.dcm"))
-        self.assertTrue(is_remote("gs://bucket/path/to/file.dcm"))
-        self.assertTrue(is_remote(self.remote_dicom_uri))
-        self.assertFalse(is_remote(self.local_instance_path))
+def test_remote_detection(local_instance_path: str):
+    assert is_remote("s3://bucket/path/to/file.dcm")
+    assert is_remote("gs://bucket/path/to/file.dcm")
+    assert is_remote(REMOTE_DICOM_URI)
+    assert not is_remote(local_instance_path)
 
-    def test_local_open(self):
-        instance = Instance(self.local_instance_path)
-        with instance.open() as f:
-            ds = pydicom3.dcmread(f)
-            self.assertEqual(ds.SOPInstanceUID, self.test_instance_uid)
 
-    def test_remote_open(self):
-        instance = Instance(self.remote_dicom_uri)
-        with instance.open() as f:
-            ds = pydicom3.dcmread(f)
-            self.assertEqual(ds.SOPInstanceUID, self.test_instance_uid)
+def test_local_open(local_instance_path: str, test_instance_uid: str):
+    instance = Instance(local_instance_path)
+    with instance.open() as f:
+        ds = pydicom3.dcmread(f)
+        assert ds.SOPInstanceUID == test_instance_uid
 
-    def test_remote_tar_open_raises_error(self):
-        instance = Instance(
-            dicom_uri="gs://some_series.tar://instances/some_instance.dcm"
-        )
-        with self.assertRaises(ValueError):
-            instance.open()
 
-    def test_validate(self):
-        instance = Instance(self.local_instance_path)
-        self.assertIsNone(instance._instance_uid)
-        self.assertIsNone(instance._series_uid)
-        self.assertIsNone(instance._study_uid)
+def test_remote_open(test_instance_uid: str):
+    instance = Instance(REMOTE_DICOM_URI)
+    with instance.open() as f:
+        ds = pydicom3.dcmread(f)
+        assert ds.SOPInstanceUID == test_instance_uid
+
+
+def test_remote_tar_open_raises_error():
+    instance = Instance(dicom_uri="gs://some_series.tar://instances/some_instance.dcm")
+    with pytest.raises(ValueError):
+        instance.open()
+
+
+def test_validate(local_instance_path: str, test_instance_uid: str):
+    instance = Instance(local_instance_path)
+    assert instance._instance_uid is None
+    assert instance._series_uid is None
+    assert instance._study_uid is None
+    instance.validate()
+    # after validation, the internal fields should be populated
+    assert instance._instance_uid == test_instance_uid
+    assert instance._series_uid == "1.2.276.0.50.192168001092.11156604.14547392.303"
+    assert instance._study_uid == "1.2.276.0.50.192168001092.11156604.14547392.4"
+    # getter methods should return the same values
+    assert instance.instance_uid() == instance._instance_uid
+    assert instance.series_uid() == instance._series_uid
+    assert instance.study_uid() == instance._study_uid
+
+
+def test_append_to_series_tar(local_instance_path: str, test_instance_uid: str):
+    instance = Instance(local_instance_path)
+    with tempfile.TemporaryDirectory() as temp_dir:
+        tar_file = os.path.join(temp_dir, "series.tar")
+        with tarfile.open(tar_file, "w") as tar:
+            pass
+        with tarfile.open(tar_file, "a") as tar:
+            instance.append_to_series_tar(tar)
+        with tarfile.open(tar_file) as tar:
+            assert len(tar.getnames()) == 1
+            assert tar.getnames()[0] == f"instances/{test_instance_uid}.dcm"
+            assert (
+                tar.getmember(f"instances/{test_instance_uid}.dcm").size
+                == instance.size()
+            )
+
+
+def test_extract_metadata(local_instance_path: str, test_instance_uid: str):
+    instance = Instance(local_instance_path)
+    assert instance._dicom_metadata is None
+    assert instance._custom_offset_tables is None
+    instance.extract_metadata(
+        output_uri="gs://some_series.tar://instances/some_instance.dcm"
+    )
+    assert instance.metadata["00080018"]["Value"][0] == test_instance_uid
+    assert instance._custom_offset_tables == {}
+
+
+def test_extract_metadata_backfills_invalid_uid(local_instance_path: str):
+    """Non-conformant UIDs (e.g. leading-zero components, >64 chars) are
+    dropped by pydicom3 when `to_json_dict(suppress_invalid_tags=True)`
+    serializes under strict_reading. _backfill_missing_uids must reinsert
+    them from the cached Instance fields populated by validate()."""
+    bad_study_uid = "1.2.840.01.2.3"  # leading zero component
+    bad_series_uid = "1.2.840.10008.5.1.4.1.2.A"  # non-digit component
+    bad_sop_uid = "1." + "2" * 70  # >64 chars
+
+    with tempfile.NamedTemporaryFile(suffix=".dcm") as tmp:
+        ds = pydicom3.dcmread(local_instance_path)
+        ds.StudyInstanceUID = bad_study_uid
+        ds.SeriesInstanceUID = bad_series_uid
+        ds.SOPInstanceUID = bad_sop_uid
+        ds.file_meta.MediaStorageSOPInstanceUID = bad_sop_uid
+        ds.save_as(tmp.name, write_like_original=False)
+
+        instance = Instance(tmp.name)
         instance.validate()
-        # after validation, the internal fields should be populated
-        self.assertEqual(instance._instance_uid, self.test_instance_uid)
-        self.assertEqual(
-            instance._series_uid, "1.2.276.0.50.192168001092.11156604.14547392.303"
-        )
-        self.assertEqual(
-            instance._study_uid, "1.2.276.0.50.192168001092.11156604.14547392.4"
-        )
-        # getter methods should return the same values
-        self.assertEqual(instance.instance_uid(), instance._instance_uid)
-        self.assertEqual(instance.series_uid(), instance._series_uid)
-        self.assertEqual(instance.study_uid(), instance._study_uid)
+        assert instance._study_uid == bad_study_uid
+        assert instance._series_uid == bad_series_uid
+        assert instance._instance_uid == bad_sop_uid
 
-    def test_append_to_series_tar(self):
-        instance = Instance(self.local_instance_path)
-        with tempfile.TemporaryDirectory() as temp_dir:
-            tar_file = os.path.join(temp_dir, "series.tar")
-            with tarfile.open(tar_file, "w") as tar:
-                pass
-            with tarfile.open(tar_file, "a") as tar:
-                instance.append_to_series_tar(tar)
-            with tarfile.open(tar_file) as tar:
-                self.assertEqual(len(tar.getnames()), 1)
-                self.assertEqual(
-                    tar.getnames()[0], f"instances/{self.test_instance_uid}.dcm"
-                )
-                self.assertEqual(
-                    tar.getmember(f"instances/{self.test_instance_uid}.dcm").size,
-                    instance.size(),
-                )
-
-    def test_extract_metadata(self):
-        instance = Instance(self.local_instance_path)
-        self.assertIsNone(instance._dicom_metadata)
-        self.assertIsNone(instance._custom_offset_tables)
         instance.extract_metadata(
             output_uri="gs://some_series.tar://instances/some_instance.dcm"
         )
-        self.assertEqual(
-            instance.metadata["00080018"]["Value"][0], self.test_instance_uid
-        )
-        self.assertEqual(instance._custom_offset_tables, {})
 
-    def test_extract_metadata_backfills_invalid_uid(self):
-        """Non-conformant UIDs (e.g. leading-zero components, >64 chars) are
-        dropped by pydicom3 when `to_json_dict(suppress_invalid_tags=True)`
-        serializes under strict_reading. _backfill_missing_uids must reinsert
-        them from the cached Instance fields populated by validate()."""
-        bad_study_uid = "1.2.840.01.2.3"  # leading zero component
-        bad_series_uid = "1.2.840.10008.5.1.4.1.2.A"  # non-digit component
-        bad_sop_uid = "1." + "2" * 70  # >64 chars
+        # Without the backfill, these tags would be missing from the JSON
+        # dict because to_json_dict(suppress_invalid_tags=True) drops them.
+        assert instance.metadata["0020000D"]["Value"][0] == bad_study_uid
+        assert instance.metadata["0020000E"]["Value"][0] == bad_series_uid
+        assert instance.metadata["00080018"]["Value"][0] == bad_sop_uid
 
-        with tempfile.NamedTemporaryFile(suffix=".dcm") as tmp:
-            ds = pydicom3.dcmread(self.local_instance_path)
-            ds.StudyInstanceUID = bad_study_uid
-            ds.SeriesInstanceUID = bad_series_uid
-            ds.SOPInstanceUID = bad_sop_uid
-            ds.file_meta.MediaStorageSOPInstanceUID = bad_sop_uid
-            ds.save_as(tmp.name, write_like_original=False)
 
-            instance = Instance(tmp.name)
-            instance.validate()
-            self.assertEqual(instance._study_uid, bad_study_uid)
-            self.assertEqual(instance._series_uid, bad_series_uid)
-            self.assertEqual(instance._instance_uid, bad_sop_uid)
+def test_delete_local_dependencies(local_instance_path: str):
+    temp_file = tempfile.NamedTemporaryFile(delete=False)
+    assert os.path.exists(temp_file.name)
+    instance = Instance(dicom_uri=local_instance_path, dependencies=[temp_file.name])
+    instance.delete_dependencies()
+    assert not os.path.exists(temp_file.name)
 
-            instance.extract_metadata(
-                output_uri="gs://some_series.tar://instances/some_instance.dcm"
-            )
 
-            # Without the backfill, these tags would be missing from the JSON
-            # dict because to_json_dict(suppress_invalid_tags=True) drops them.
-            self.assertEqual(instance.metadata["0020000D"]["Value"][0], bad_study_uid)
-            self.assertEqual(instance.metadata["0020000E"]["Value"][0], bad_series_uid)
-            self.assertEqual(instance.metadata["00080018"]["Value"][0], bad_sop_uid)
+def test_open_invalid_file():
+    """Test that we raise an error if the file is not a dicom file"""
+    instance = Instance(dicom_uri=f"{os.path.dirname(__file__)}/test_appender.py")
+    with pytest.raises(AssertionError):
+        instance.open()
 
-    def test_delete_local_dependencies(self):
-        temp_file = tempfile.NamedTemporaryFile(delete=False)
-        self.assertTrue(os.path.exists(temp_file.name))
-        instance = Instance(
-            dicom_uri=self.local_instance_path, dependencies=[temp_file.name]
-        )
-        instance.delete_dependencies()
-        self.assertFalse(os.path.exists(temp_file.name))
 
-    def test_open_invalid_file(self):
-        """Test that we raise an error if the file is not a dicom file"""
-        instance = Instance(dicom_uri=f"{os.path.dirname(__file__)}/test_appender.py")
-        with self.assertRaises(AssertionError):
-            instance.open()
+def test_has_pixeldata_property(local_instance_path: str):
+    """Test that we can determine if a local dicom file has pixel data"""
+    instance = Instance(dicom_uri=local_instance_path)
+    assert instance._has_pixeldata is None  # Verify it's None before fetch
+    assert instance.has_pixeldata
 
-    def test_has_pixeldata_property(self):
-        """Test that we can determine if a local dicom file has pixel data"""
-        instance = Instance(dicom_uri=self.local_instance_path)
-        assert instance._has_pixeldata is None  # Verify it's None before fetch
-        self.assertTrue(instance.has_pixeldata)
 
-    def test_compress(self):
-        """Test that we can compress an instance to the given syntax"""
-        instance = Instance(dicom_uri=self.local_instance_path)
-        with instance.open() as f:
-            ds = pydicom3.dcmread(f)
-            self.assertEqual(
-                ds.file_meta.TransferSyntaxUID, pydicom3.uid.ImplicitVRLittleEndian
-            )
-        uncompressed_size = instance.size()
-        instance.compress()
-        self.assertLess(instance.size(), uncompressed_size)
-        with instance.open() as f:
-            ds = pydicom3.dcmread(f)
-            self.assertEqual(
-                ds.file_meta.TransferSyntaxUID, pydicom3.uid.JPEG2000Lossless
-            )
-        # Should be pointing to the new temp file
-        self.assertEqual(instance._temp_file_path, instance.dicom_uri)
-        self.assertNotEqual(instance.dicom_uri, self.local_instance_path)
+def test_compress(local_instance_path: str):
+    """Test that we can compress an instance to the given syntax"""
+    instance = Instance(dicom_uri=local_instance_path)
+    with instance.open() as f:
+        ds = pydicom3.dcmread(f)
+        assert ds.file_meta.TransferSyntaxUID == pydicom3.uid.ImplicitVRLittleEndian
+    uncompressed_size = instance.size()
+    instance.compress()
+    assert instance.size() < uncompressed_size
+    with instance.open() as f:
+        ds = pydicom3.dcmread(f)
+        assert ds.file_meta.TransferSyntaxUID == pydicom3.uid.JPEG2000Lossless
+    # Should be pointing to the new temp file
+    assert instance._temp_file_path == instance.dicom_uri
+    assert instance.dicom_uri != local_instance_path
 
-    def test_temp_file_cleanup(self):
-        """Test that the temp file is cleaned up when the instance is deleted"""
-        # make a temp file with valid dicom data
-        temp_file = tempfile.NamedTemporaryFile(suffix="_TEST.dcm", delete=False)
-        with open(temp_file.name, "wb") as out:
-            with open(
-                os.path.join(self.test_data_dir, "monochrome2.dcm"), "rb"
-            ) as in_file:
-                out.write(in_file.read())
-        # make an instance with the temp file
-        instance = Instance(dicom_uri=temp_file.name, _temp_file_path=temp_file.name)
-        self.assertIsNotNone(instance._temp_file_path)
-        # make sure we can read the instance
-        with instance.open() as f:
-            ds = pydicom3.dcmread(f)
-            self.assertEqual(ds.SOPInstanceUID, self.test_instance_uid)
-        # delete the instance - this should clean up the temp file
-        del instance
-        self.assertFalse(os.path.exists(temp_file.name))
+
+def test_temp_file_cleanup(test_data_dir: str, test_instance_uid: str):
+    """Test that the temp file is cleaned up when the instance is deleted"""
+    # make a temp file with valid dicom data
+    temp_file = tempfile.NamedTemporaryFile(suffix="_TEST.dcm", delete=False)
+    with open(temp_file.name, "wb") as out:
+        with open(os.path.join(test_data_dir, "monochrome2.dcm"), "rb") as in_file:
+            out.write(in_file.read())
+    # make an instance with the temp file
+    instance = Instance(dicom_uri=temp_file.name, _temp_file_path=temp_file.name)
+    assert instance._temp_file_path is not None
+    # make sure we can read the instance
+    with instance.open() as f:
+        ds = pydicom3.dcmread(f)
+        assert ds.SOPInstanceUID == test_instance_uid
+    # delete the instance - this should clean up the temp file
+    del instance
+    assert not os.path.exists(temp_file.name)

--- a/cloud_optimized_dicom/tests/test_locking.py
+++ b/cloud_optimized_dicom/tests/test_locking.py
@@ -1,7 +1,6 @@
-import os
-import unittest
+import warnings
 
-from google.api_core.client_options import ClientOptions
+import pytest
 from google.cloud import storage
 
 from cloud_optimized_dicom.cod_object import CODObject
@@ -10,344 +9,423 @@ from cloud_optimized_dicom.instance import Instance
 from cloud_optimized_dicom.series_metadata import SeriesMetadata
 from cloud_optimized_dicom.utils import delete_uploaded_blobs
 
+LOCK_STUDY_UID = "1.2.3.4.5.6.7.8.9.10"
+LOCK_SERIES_UID = "1.2.3.4.5.6.7.8.9.10"
 
-class TestLocking(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        # Uncomment if needed to help debug tests
-        # logging.basicConfig(level=logging.INFO)
-        # logging.getLogger().setLevel(logging.INFO)
-        cls.client = storage.Client(
-            project="gradient-pacs-siskin-172863",
-            client_options=ClientOptions(
-                quota_project_id="gradient-pacs-siskin-172863"
-            ),
+
+@pytest.fixture
+def lock_study_uid() -> str:
+    return LOCK_STUDY_UID
+
+
+@pytest.fixture
+def lock_series_uid() -> str:
+    return LOCK_SERIES_UID
+
+
+def test_mode_unspecified(
+    gcs_client: storage.Client,
+    datastore_path: str,
+    lock_study_uid: str,
+    lock_series_uid: str,
+):
+    """Test that not specifying mode raises an error"""
+    with pytest.raises(ValueError):
+        CODObject(
+            datastore_path=datastore_path,
+            client=gcs_client,
+            study_uid=lock_study_uid,
+            series_uid=lock_series_uid,
         )
-        cls.datastore_path = "gs://siskin-172863-temp/cod_tests/dicomweb"
-        cls.study_uid = "1.2.3.4.5.6.7.8.9.10"
-        cls.series_uid = "1.2.3.4.5.6.7.8.9.10"
-        cls.test_data_dir = os.path.join(os.path.dirname(__file__), "test_data")
-        cls.local_instance_path = os.path.join(cls.test_data_dir, "monochrome2.dcm")
-        delete_uploaded_blobs(cls.client, [cls.datastore_path])
 
-    def test_mode_unspecified(self):
-        """Test that not specifying mode raises an error"""
-        with self.assertRaises(ValueError):
-            CODObject(
-                datastore_path=self.datastore_path,
-                client=self.client,
-                study_uid=self.study_uid,
-                series_uid=self.series_uid,
-            )
 
-    def test_lock_immutability(self):
-        """Test that the lock flag is immutable"""
-        with CODObject(
-            client=self.client,
-            datastore_path=self.datastore_path,
-            study_uid=self.study_uid,
-            series_uid=self.series_uid,
-            mode="r",
-        ) as cod:
-            with self.assertRaises(AttributeError):
-                cod.lock = True
+def test_lock_immutability(
+    gcs_client: storage.Client,
+    datastore_path: str,
+    lock_study_uid: str,
+    lock_series_uid: str,
+):
+    """Test that the lock flag is immutable"""
+    with CODObject(
+        client=gcs_client,
+        datastore_path=datastore_path,
+        study_uid=lock_study_uid,
+        series_uid=lock_series_uid,
+        mode="r",
+    ) as cod:
+        with pytest.raises(AttributeError):
+            cod.lock = True
 
-    def test_lock_uniqueness(self):
-        """Test that you cannot have two CODObjects with the same lock"""
-        with CODObject(
-            client=self.client,
-            datastore_path=self.datastore_path,
-            study_uid=self.study_uid,
-            series_uid=self.series_uid,
-            mode="w",
-        ) as cod1:
-            with self.assertRaises(LockAcquisitionError):
-                with CODObject(
-                    client=self.client,
-                    datastore_path=self.datastore_path,
-                    study_uid=self.study_uid,
-                    series_uid=self.series_uid,
-                    mode="w",
-                ) as cod2:
-                    pass
 
-    def test_read_mode(self):
-        """Test that you can read metadata in read mode"""
-        with CODObject(
-            client=self.client,
-            datastore_path=self.datastore_path,
-            study_uid=self.study_uid,
-            series_uid=self.series_uid,
-            mode="r",
-        ) as cod:
-            metadata = cod.get_metadata()
-            self.assertEqual(metadata.study_uid, self.study_uid)
-            self.assertEqual(metadata.series_uid, self.series_uid)
-
-    def test_concurrent_read(self):
-        """Test that you can read while another cod has a lock"""
-        with CODObject(
-            client=self.client,
-            datastore_path=self.datastore_path,
-            study_uid=self.study_uid,
-            series_uid=self.series_uid,
-            mode="w",
-        ) as cod1:
-            locked_metadata = cod1.get_metadata()
+def test_lock_uniqueness(
+    gcs_client: storage.Client,
+    datastore_path: str,
+    lock_study_uid: str,
+    lock_series_uid: str,
+):
+    """Test that you cannot have two CODObjects with the same lock"""
+    with CODObject(
+        client=gcs_client,
+        datastore_path=datastore_path,
+        study_uid=lock_study_uid,
+        series_uid=lock_series_uid,
+        mode="w",
+    ) as cod1:
+        with pytest.raises(LockAcquisitionError):
             with CODObject(
-                client=self.client,
-                datastore_path=self.datastore_path,
-                study_uid=self.study_uid,
-                series_uid=self.series_uid,
-                mode="r",
+                client=gcs_client,
+                datastore_path=datastore_path,
+                study_uid=lock_study_uid,
+                series_uid=lock_series_uid,
+                mode="w",
             ) as cod2:
-                read_metadata = cod2.get_metadata()
-                self.assertEqual(read_metadata.study_uid, self.study_uid)
-                self.assertEqual(read_metadata.series_uid, self.series_uid)
-                self.assertEqual(locked_metadata.study_uid, self.study_uid)
-                self.assertEqual(locked_metadata.series_uid, self.series_uid)
-
-    def test_read_mode_allows_reads(self):
-        """Test that mode='r' allows read operations without errors"""
-        with CODObject(
-            client=self.client,
-            datastore_path=self.datastore_path,
-            study_uid=self.study_uid,
-            series_uid=self.series_uid,
-            mode="r",
-        ) as cod:
-            # Read operations should work without any dirty parameter
-            metadata = cod.get_metadata()
-            self.assertEqual(metadata.study_uid, self.study_uid)
-            self.assertEqual(metadata.series_uid, self.series_uid)
-
-    def test_deprecation_warning_for_dirty_param(self):
-        """Test that using dirty parameter emits a deprecation warning"""
-        import warnings
-
-        with CODObject(
-            client=self.client,
-            datastore_path=self.datastore_path,
-            study_uid=self.study_uid,
-            series_uid=self.series_uid,
-            mode="r",
-        ) as cod:
-            with warnings.catch_warnings(record=True) as w:
-                warnings.simplefilter("always")
-                cod.get_metadata(dirty=True)
-                # Check that a deprecation warning was issued for the dirty parameter
-                self.assertTrue(
-                    any("dirty" in str(warning.message) for warning in w),
-                    "Expected deprecation warning for 'dirty' parameter",
-                )
-
-    def test_lock_gone_on_cleanup(self):
-        """Test that we get an error if the lock disappears while the COD is active"""
-        with self.assertRaises(LockVerificationError):
-            with CODObject(
-                client=self.client,
-                datastore_path=self.datastore_path,
-                study_uid=self.study_uid,
-                series_uid=self.series_uid,
-                mode="w",
-            ) as cod:
-                cod._locker.get_lock_blob().delete()
-            # when the with block exits, cod will attempt to release the lock and will find it missing
-
-    @unittest.skip("skipping until we have a sync method")
-    def test_lock_gone_on_sync(self):
-        """Test that we get an error if the lock disappears while the COD is syncing"""
-        # don't use a with block so we can delete the lock blob manually
-        cod_obj = CODObject(
-            client=self.client,
-            datastore_path=self.datastore_path,
-            study_uid=self.study_uid,
-            series_uid=self.series_uid,
-            mode="w",
-        )
-        cod_obj.get_lock_blob().delete()
-        with self.assertRaises(LockVerificationError):
-            cod_obj._sync()
-
-    def test_lock_changes(self):
-        """Test that we get an error if the lock changes while the COD is active"""
-        with self.assertRaises(LockVerificationError):
-            with CODObject(
-                client=self.client,
-                datastore_path=self.datastore_path,
-                study_uid=self.study_uid,
-                series_uid=self.series_uid,
-                mode="w",
-            ) as cod:
-                # simulate some other cod somehow stealing the lock
-                cod._locker.get_lock_blob().upload_from_string(
-                    "", content_type="application/octet-stream"
-                )
-            # when the with block exits, cod will attempt to release the lock and will find it changed
-        # cod will have failed to delete the lock since it assumes it belongs to another cod, so we need to clean up after ourselves
-        delete_uploaded_blobs(self.client, [self.datastore_path])
-
-    def test_lock_stolen_during_metadata_fetch(self):
-        """Test that we get an error if another process creates the lock while we're fetching metadata"""
-
-        original_get_metadata = CODObject._get_metadata
-
-        def mock_get_metadata(self: CODObject, create_if_missing=True):
-            # First get the metadata normally
-            result = original_get_metadata(self, create_if_missing=create_if_missing)
-            # Then simulate another process creating the lock file
-            self._locker.get_lock_blob().upload_from_string(
-                "competing lock", content_type="application/json", if_generation_match=0
-            )
-            return result
-
-        # Patch the _get_metadata method temporarily for this test.
-        # Now in acquire_lock, it will now get_metadata, upload a lock, and then attempt to upload the lock again
-        # We expect this to raise our assertion error about a stolen lock
-        CODObject._get_metadata = mock_get_metadata
-
-        try:
-            with self.assertRaisesRegex(
-                LockAcquisitionError,
-                "COD:LOCK:ACQUISITION_FAILED:STOLEN_DURING_METADATA_FETCH",
-            ):
-                CODObject(
-                    client=self.client,
-                    datastore_path=self.datastore_path,
-                    study_uid=self.study_uid,
-                    series_uid=self.series_uid,
-                    mode="w",
-                )
-        finally:
-            # Restore the original method
-            CODObject._get_metadata = original_get_metadata
-            # Clean up any locks that might have been created
-            delete_uploaded_blobs(self.client, [self.datastore_path])
-
-    def test_lock_released_after_non_sync_exception(self):
-        """Test that the lock is released after a non-sync exception (only local state is corrupt)"""
-        with self.assertRaises(ValueError):
-            with CODObject(
-                client=self.client,
-                datastore_path=self.datastore_path,
-                study_uid=self.study_uid,
-                series_uid=self.series_uid,
-                mode="w",
-            ) as cod:
-                raise ValueError("test")
-        # Sync should NOT have been called -> tracker vars should be False
-        self.assertFalse(cod._tar_synced)
-        self.assertFalse(cod._metadata_synced)
-        # The lock should have been released (only sync failures leave hanging locks)
-        self.assertFalse(cod._locker.get_lock_blob().exists())
-
-    def test_release_failure_preserves_original_exception(self):
-        """Test that if release fails during cleanup of a non-sync exception, the original exception propagates"""
-        with self.assertRaises(ValueError):
-            with CODObject(
-                client=self.client,
-                datastore_path=self.datastore_path,
-                study_uid=self.study_uid,
-                series_uid=self.series_uid,
-                mode="w",
-            ) as cod:
-                # tamper with the lock so release() will fail
-                cod._locker.get_lock_blob().upload_from_string(
-                    "", content_type="application/octet-stream"
-                )
-                raise ValueError("original error")
-        # caller should see ValueError, not LockVerificationError
-        # lock is left hanging (tampered), clean up
-        delete_uploaded_blobs(self.client, [self.datastore_path])
-
-    def test_override_stale_lock(self):
-        """Test that we can override a stale lock"""
-        # leave a hanging lock by causing a sync failure (tamper with lock generation)
-        with self.assertRaises(LockVerificationError):
-            with CODObject(
-                client=self.client,
-                datastore_path=self.datastore_path,
-                study_uid=self.study_uid,
-                series_uid=self.series_uid,
-                mode="w",
-            ) as cod:
-                # re-upload lock with same metadata but new generation → verify fails on exit
-                lock_blob = cod._locker.get_lock_blob()
-                lock_blob.content_encoding = "gzip"
-                lock_blob.upload_from_string(
-                    cod._metadata.to_gzipped_json(),
-                    content_type="application/json",
-                )
-        # because there's a hanging lock, we should get an error
-        with self.assertRaises(LockAcquisitionError):
-            with CODObject(
-                client=self.client,
-                datastore_path=self.datastore_path,
-                study_uid=self.study_uid,
-                series_uid=self.series_uid,
-                mode="w",
-            ) as cod:
                 pass
 
-        # we should be able to override the lock with a sufficiently small age threshold
+
+def test_read_mode(
+    gcs_client: storage.Client,
+    datastore_path: str,
+    lock_study_uid: str,
+    lock_series_uid: str,
+):
+    """Test that you can read metadata in read mode"""
+    with CODObject(
+        client=gcs_client,
+        datastore_path=datastore_path,
+        study_uid=lock_study_uid,
+        series_uid=lock_series_uid,
+        mode="r",
+    ) as cod:
+        metadata = cod.get_metadata()
+        assert metadata.study_uid == lock_study_uid
+        assert metadata.series_uid == lock_series_uid
+
+
+def test_concurrent_read(
+    gcs_client: storage.Client,
+    datastore_path: str,
+    lock_study_uid: str,
+    lock_series_uid: str,
+):
+    """Test that you can read while another cod has a lock"""
+    with CODObject(
+        client=gcs_client,
+        datastore_path=datastore_path,
+        study_uid=lock_study_uid,
+        series_uid=lock_series_uid,
+        mode="w",
+    ) as cod1:
+        locked_metadata = cod1.get_metadata()
         with CODObject(
-            client=self.client,
-            datastore_path=self.datastore_path,
-            study_uid=self.study_uid,
-            series_uid=self.series_uid,
+            client=gcs_client,
+            datastore_path=datastore_path,
+            study_uid=lock_study_uid,
+            series_uid=lock_series_uid,
+            mode="r",
+        ) as cod2:
+            read_metadata = cod2.get_metadata()
+            assert read_metadata.study_uid == lock_study_uid
+            assert read_metadata.series_uid == lock_series_uid
+            assert locked_metadata.study_uid == lock_study_uid
+            assert locked_metadata.series_uid == lock_series_uid
+
+
+def test_read_mode_allows_reads(
+    gcs_client: storage.Client,
+    datastore_path: str,
+    lock_study_uid: str,
+    lock_series_uid: str,
+):
+    """Test that mode='r' allows read operations without errors"""
+    with CODObject(
+        client=gcs_client,
+        datastore_path=datastore_path,
+        study_uid=lock_study_uid,
+        series_uid=lock_series_uid,
+        mode="r",
+    ) as cod:
+        # Read operations should work without any dirty parameter
+        metadata = cod.get_metadata()
+        assert metadata.study_uid == lock_study_uid
+        assert metadata.series_uid == lock_series_uid
+
+
+def test_deprecation_warning_for_dirty_param(
+    gcs_client: storage.Client,
+    datastore_path: str,
+    lock_study_uid: str,
+    lock_series_uid: str,
+):
+    """Test that using dirty parameter emits a deprecation warning"""
+    with CODObject(
+        client=gcs_client,
+        datastore_path=datastore_path,
+        study_uid=lock_study_uid,
+        series_uid=lock_series_uid,
+        mode="r",
+    ) as cod:
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            cod.get_metadata(dirty=True)
+            # Check that a deprecation warning was issued for the dirty parameter
+            assert any(
+                "dirty" in str(warning.message) for warning in w
+            ), "Expected deprecation warning for 'dirty' parameter"
+
+
+def test_lock_gone_on_cleanup(
+    gcs_client: storage.Client,
+    datastore_path: str,
+    lock_study_uid: str,
+    lock_series_uid: str,
+):
+    """Test that we get an error if the lock disappears while the COD is active"""
+    with pytest.raises(LockVerificationError):
+        with CODObject(
+            client=gcs_client,
+            datastore_path=datastore_path,
+            study_uid=lock_study_uid,
+            series_uid=lock_series_uid,
+            mode="w",
+        ) as cod:
+            cod._locker.get_lock_blob().delete()
+        # when the with block exits, cod will attempt to release the lock and will find it missing
+
+
+@pytest.mark.skip(reason="skipping until we have a sync method")
+def test_lock_gone_on_sync(
+    gcs_client: storage.Client,
+    datastore_path: str,
+    lock_study_uid: str,
+    lock_series_uid: str,
+):
+    """Test that we get an error if the lock disappears while the COD is syncing"""
+    # don't use a with block so we can delete the lock blob manually
+    cod_obj = CODObject(
+        client=gcs_client,
+        datastore_path=datastore_path,
+        study_uid=lock_study_uid,
+        series_uid=lock_series_uid,
+        mode="w",
+    )
+    cod_obj.get_lock_blob().delete()
+    with pytest.raises(LockVerificationError):
+        cod_obj._sync()
+
+
+def test_lock_changes(
+    gcs_client: storage.Client,
+    datastore_path: str,
+    lock_study_uid: str,
+    lock_series_uid: str,
+):
+    """Test that we get an error if the lock changes while the COD is active"""
+    with pytest.raises(LockVerificationError):
+        with CODObject(
+            client=gcs_client,
+            datastore_path=datastore_path,
+            study_uid=lock_study_uid,
+            series_uid=lock_series_uid,
+            mode="w",
+        ) as cod:
+            # simulate some other cod somehow stealing the lock
+            cod._locker.get_lock_blob().upload_from_string(
+                "", content_type="application/octet-stream"
+            )
+        # when the with block exits, cod will attempt to release the lock and will find it changed
+    # cod will have failed to delete the lock since it assumes it belongs to another cod, so we need to clean up after ourselves
+    delete_uploaded_blobs(gcs_client, [datastore_path])
+
+
+def test_lock_stolen_during_metadata_fetch(
+    gcs_client: storage.Client,
+    datastore_path: str,
+    lock_study_uid: str,
+    lock_series_uid: str,
+):
+    """Test that we get an error if another process creates the lock while we're fetching metadata"""
+
+    original_get_metadata = CODObject._get_metadata
+
+    def mock_get_metadata(self: CODObject, create_if_missing=True):
+        # First get the metadata normally
+        result = original_get_metadata(self, create_if_missing=create_if_missing)
+        # Then simulate another process creating the lock file
+        self._locker.get_lock_blob().upload_from_string(
+            "competing lock",
+            content_type="application/json",
+            if_generation_match=0,
+        )
+        return result
+
+    # Patch the _get_metadata method temporarily for this test.
+    # Now in acquire_lock, it will now get_metadata, upload a lock, and then attempt to upload the lock again
+    # We expect this to raise our assertion error about a stolen lock
+    CODObject._get_metadata = mock_get_metadata
+
+    try:
+        with pytest.raises(
+            LockAcquisitionError,
+            match="COD:LOCK:ACQUISITION_FAILED:STOLEN_DURING_METADATA_FETCH",
+        ):
+            CODObject(
+                client=gcs_client,
+                datastore_path=datastore_path,
+                study_uid=lock_study_uid,
+                series_uid=lock_series_uid,
+                mode="w",
+            )
+    finally:
+        # Restore the original method
+        CODObject._get_metadata = original_get_metadata
+        # Clean up any locks that might have been created
+        delete_uploaded_blobs(gcs_client, [datastore_path])
+
+
+def test_lock_released_after_non_sync_exception(
+    gcs_client: storage.Client,
+    datastore_path: str,
+    lock_study_uid: str,
+    lock_series_uid: str,
+):
+    """Test that the lock is released after a non-sync exception (only local state is corrupt)"""
+    with pytest.raises(ValueError):
+        with CODObject(
+            client=gcs_client,
+            datastore_path=datastore_path,
+            study_uid=lock_study_uid,
+            series_uid=lock_series_uid,
+            mode="w",
+        ) as cod:
+            raise ValueError("test")
+    # Sync should NOT have been called -> tracker vars should be False
+    assert not cod._tar_synced
+    assert not cod._metadata_synced
+    # The lock should have been released (only sync failures leave hanging locks)
+    assert not cod._locker.get_lock_blob().exists()
+
+
+def test_release_failure_preserves_original_exception(
+    gcs_client: storage.Client,
+    datastore_path: str,
+    lock_study_uid: str,
+    lock_series_uid: str,
+):
+    """Test that if release fails during cleanup of a non-sync exception, the original exception propagates"""
+    with pytest.raises(ValueError):
+        with CODObject(
+            client=gcs_client,
+            datastore_path=datastore_path,
+            study_uid=lock_study_uid,
+            series_uid=lock_series_uid,
+            mode="w",
+        ) as cod:
+            # tamper with the lock so release() will fail
+            cod._locker.get_lock_blob().upload_from_string(
+                "", content_type="application/octet-stream"
+            )
+            raise ValueError("original error")
+    # caller should see ValueError, not LockVerificationError
+    # lock is left hanging (tampered), clean up
+    delete_uploaded_blobs(gcs_client, [datastore_path])
+
+
+def test_override_stale_lock(
+    gcs_client: storage.Client,
+    datastore_path: str,
+    lock_study_uid: str,
+    lock_series_uid: str,
+):
+    """Test that we can override a stale lock"""
+    # leave a hanging lock by causing a sync failure (tamper with lock generation)
+    with pytest.raises(LockVerificationError):
+        with CODObject(
+            client=gcs_client,
+            datastore_path=datastore_path,
+            study_uid=lock_study_uid,
+            series_uid=lock_series_uid,
+            mode="w",
+        ) as cod:
+            # re-upload lock with same metadata but new generation → verify fails on exit
+            lock_blob = cod._locker.get_lock_blob()
+            lock_blob.content_encoding = "gzip"
+            lock_blob.upload_from_string(
+                cod._metadata.to_gzipped_json(),
+                content_type="application/json",
+            )
+    # because there's a hanging lock, we should get an error
+    with pytest.raises(LockAcquisitionError):
+        with CODObject(
+            client=gcs_client,
+            datastore_path=datastore_path,
+            study_uid=lock_study_uid,
+            series_uid=lock_series_uid,
+            mode="w",
+        ) as cod:
+            pass
+
+    # we should be able to override the lock with a sufficiently small age threshold
+    with CODObject(
+        client=gcs_client,
+        datastore_path=datastore_path,
+        study_uid=lock_study_uid,
+        series_uid=lock_series_uid,
+        mode="w",
+        empty_lock_override_age=0.00000001,
+    ) as cod:
+        pass
+    # The lock should have been overridden and released
+    assert not cod._locker.get_lock_blob().exists()
+    # clean up any locks that might have been created
+    delete_uploaded_blobs(gcs_client, [datastore_path])
+
+
+def test_cannot_override_non_empty_lock(
+    gcs_client: storage.Client,
+    datastore_path: str,
+    local_instance_path: str,
+):
+    """Test that we cannot override a non-empty lock"""
+    instance = Instance(dicom_uri=local_instance_path)
+    # append an instance to the cod object so it exists in the datastore
+    with CODObject(
+        client=gcs_client,
+        datastore_path=datastore_path,
+        study_uid=instance.study_uid(),
+        series_uid=instance.series_uid(),
+        mode="w",
+    ) as cod:
+        cod.append([instance])
+
+    # create a non-empty hanging lock by causing a sync failure
+    # use mode="a" so the lock snapshot includes the existing instances
+    with pytest.raises(LockVerificationError):
+        with CODObject(
+            client=gcs_client,
+            datastore_path=datastore_path,
+            study_uid=instance.study_uid(),
+            series_uid=instance.series_uid(),
+            mode="a",
+        ) as cod:
+            # re-upload lock with current metadata (has instances) but new generation
+            lock_blob = cod._locker.get_lock_blob()
+            lock_blob.content_encoding = "gzip"
+            lock_blob.upload_from_string(
+                cod._metadata.to_gzipped_json(),
+                content_type="application/json",
+            )
+    # assert lock exists
+    assert cod._locker.get_lock_blob().exists()
+    # assert lock is non empty
+    assert len(SeriesMetadata.from_blob(cod._locker.get_lock_blob()).instances) > 0
+    # we should not be able to override the lock, even with a sufficiently small age threshold
+    with pytest.raises(LockAcquisitionError):
+        with CODObject(
+            client=gcs_client,
+            datastore_path=datastore_path,
+            study_uid=instance.study_uid(),
+            series_uid=instance.series_uid(),
             mode="w",
             empty_lock_override_age=0.00000001,
         ) as cod:
             pass
-        # The lock should have been overridden and released
-        self.assertFalse(cod._locker.get_lock_blob().exists())
-        # clean up any locks that might have been created
-        delete_uploaded_blobs(self.client, [self.datastore_path])
-
-    def test_cannot_override_non_empty_lock(self):
-        """Test that we cannot override a non-empty lock"""
-        instance = Instance(dicom_uri=self.local_instance_path)
-        # append an instance to the cod object so it exists in the datastore
-        with CODObject(
-            client=self.client,
-            datastore_path=self.datastore_path,
-            study_uid=instance.study_uid(),
-            series_uid=instance.series_uid(),
-            mode="w",
-        ) as cod:
-            cod.append([instance])
-
-        # create a non-empty hanging lock by causing a sync failure
-        # use mode="a" so the lock snapshot includes the existing instances
-        with self.assertRaises(LockVerificationError):
-            with CODObject(
-                client=self.client,
-                datastore_path=self.datastore_path,
-                study_uid=instance.study_uid(),
-                series_uid=instance.series_uid(),
-                mode="a",
-            ) as cod:
-                # re-upload lock with current metadata (has instances) but new generation
-                lock_blob = cod._locker.get_lock_blob()
-                lock_blob.content_encoding = "gzip"
-                lock_blob.upload_from_string(
-                    cod._metadata.to_gzipped_json(),
-                    content_type="application/json",
-                )
-        # assert lock exists
-        self.assertTrue(cod._locker.get_lock_blob().exists())
-        # assert lock is non empty
-        self.assertGreater(
-            len(SeriesMetadata.from_blob(cod._locker.get_lock_blob()).instances), 0
-        )
-        # we should not be able to override the lock, even with a sufficiently small age threshold
-        with self.assertRaises(LockAcquisitionError):
-            with CODObject(
-                client=self.client,
-                datastore_path=self.datastore_path,
-                study_uid=instance.study_uid(),
-                series_uid=instance.series_uid(),
-                mode="w",
-                empty_lock_override_age=0.00000001,
-            ) as cod:
-                pass

--- a/cloud_optimized_dicom/tests/test_metadata_serialization.py
+++ b/cloud_optimized_dicom/tests/test_metadata_serialization.py
@@ -1,248 +1,222 @@
 import json
 import os
-import unittest
+
+import pytest
 
 from cloud_optimized_dicom.instance_metadata import CompressedDicomMetadata
 from cloud_optimized_dicom.series_metadata import SeriesMetadata
 
 
-class TestMetadataSerialization(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        cls.test_data_dir = os.path.join(os.path.dirname(__file__), "test_data")
+def _assert_load_success(metadata: SeriesMetadata):
+    # make sure all expected cod metadata is present
+    assert metadata.study_uid == "some_study_uid"
+    assert metadata.series_uid == "some_series_uid"
+    assert list(metadata.instances.keys()) == ["instance_uid_1", "instance_uid_2"]
+    # check a specific instance for thoroughness
+    loaded_instance = metadata.instances["instance_uid_1"]
+    assert (
+        loaded_instance.dicom_uri
+        == "gs://some-hospital-pacs/v1.0/dicomweb/studies/some_study_uid/series/some_series_uid.tar://instances/instance_uid_1.dcm"
+    )
+    assert loaded_instance._byte_offsets == (1536, 393554)
+    assert loaded_instance._crc32c == "MdpbMQ=="
+    assert loaded_instance._size == 392018
+    assert loaded_instance._original_path == "gs://path/to/original.dcm"
+    assert loaded_instance.dependencies == ["gs://path/to/original.dcm"]
+    assert loaded_instance._diff_hash_dupe_paths == []
+    assert loaded_instance._modified_datetime == "2025-02-26T01:25:49.250660"
+    assert loaded_instance._custom_offset_tables == {}
+    # check some random metadata value for thoroughness
+    assert metadata.instances["instance_uid_1"].metadata["00080000"]["Value"] == [612]
 
-    def _assert_load_success(self, metadata: SeriesMetadata):
-        # make sure all expected cod metadata is present
-        self.assertEqual(metadata.study_uid, "some_study_uid")
-        self.assertEqual(metadata.series_uid, "some_series_uid")
-        self.assertListEqual(
-            list(metadata.instances.keys()), ["instance_uid_1", "instance_uid_2"]
-        )
-        # check a specific instance for thoroughness
-        loaded_instance = metadata.instances["instance_uid_1"]
-        self.assertEqual(
-            loaded_instance.dicom_uri,
-            "gs://some-hospital-pacs/v1.0/dicomweb/studies/some_study_uid/series/some_series_uid.tar://instances/instance_uid_1.dcm",
-        )
-        self.assertEqual(loaded_instance._byte_offsets, (1536, 393554))
-        self.assertEqual(loaded_instance._crc32c, "MdpbMQ==")
-        self.assertEqual(loaded_instance._size, 392018)
-        self.assertEqual(loaded_instance._original_path, "gs://path/to/original.dcm")
-        self.assertEqual(loaded_instance.dependencies, ["gs://path/to/original.dcm"])
-        self.assertEqual(loaded_instance._diff_hash_dupe_paths, [])
-        self.assertEqual(
-            loaded_instance._modified_datetime, "2025-02-26T01:25:49.250660"
-        )
-        self.assertEqual(loaded_instance._custom_offset_tables, {})
-        # check some random metadata value for thoroughness
-        self.assertEqual(
-            metadata.instances["instance_uid_1"].metadata["00080000"]["Value"], [612]
-        )
+    # make sure thumbnail custom tags are present
+    assert list(metadata.metadata_fields.keys()) == ["thumbnail"]
+    assert list(metadata.metadata_fields["thumbnail"].keys()) == [
+        "uri",
+        "thumbnail_index_to_instance_frame",
+        "instances",
+        "version",
+    ]
 
-        # make sure thumbnail custom tags are present
-        self.assertListEqual(list(metadata.metadata_fields.keys()), ["thumbnail"])
-        self.assertListEqual(
-            list(metadata.metadata_fields["thumbnail"].keys()),
-            ["uri", "thumbnail_index_to_instance_frame", "instances", "version"],
-        )
 
-    def _assert_save_success(self, raw_dict: dict, saved_dict: dict, is_deid: bool):
-        # top level key assertion first for ease of debugging
-        self.assertEqual(raw_dict.keys(), saved_dict.keys())
-        # uids must be equal
-        if is_deid:
-            self.assertEqual(
-                raw_dict.pop("deid_study_uid", None),
-                saved_dict.pop("deid_study_uid", None),
-            )
-            self.assertEqual(
-                raw_dict.pop("deid_series_uid", None),
-                saved_dict.pop("deid_series_uid", None),
-            )
+def _assert_save_success(raw_dict: dict, saved_dict: dict, is_deid: bool):
+    # top level key assertion first for ease of debugging
+    assert raw_dict.keys() == saved_dict.keys()
+    # uids must be equal
+    if is_deid:
+        assert raw_dict.pop("deid_study_uid", None) == saved_dict.pop(
+            "deid_study_uid", None
+        )
+        assert raw_dict.pop("deid_series_uid", None) == saved_dict.pop(
+            "deid_series_uid", None
+        )
+    else:
+        assert raw_dict.pop("study_uid", None) == saved_dict.pop("study_uid", None)
+        assert raw_dict.pop("series_uid", None) == saved_dict.pop("series_uid", None)
+    # pop off cod dict for comparison later (it is the most complex)
+    raw_cod = raw_dict.pop("cod")
+    saved_cod = saved_dict.pop("cod")
+    # check remaining dicts (custom tags) are equal
+    assert raw_dict == saved_dict
+    # now do cod dict comparison
+    assert raw_cod.keys() == saved_cod.keys()
+    for instance_uid in raw_cod["instances"].keys():
+        raw_instance = raw_cod["instances"][instance_uid]
+        saved_instance = saved_cod["instances"][instance_uid]
+        assert all(raw_key in saved_instance.keys() for raw_key in raw_instance.keys())
+        # Handle version differences: v1 has dict metadata, v2 has compressed string
+        raw_version = raw_instance.get("version", "1.0")
+        saved_version = saved_instance.get("version", "1.0")
+        if raw_version == "1.0" and saved_version == "2.0":
+            # v1 → v2 upgrade: metadata is now compressed, skip metadata and version comparison
+            # but verify it's a string
+            assert isinstance(saved_instance["metadata"], str)
+            # Compare all other fields (skip metadata and version)
+            for key in raw_instance.keys():
+                if key not in ("metadata", "version"):
+                    assert raw_instance[key] == saved_instance[key]
         else:
-            self.assertEqual(
-                raw_dict.pop("study_uid", None), saved_dict.pop("study_uid", None)
-            )
-            self.assertEqual(
-                raw_dict.pop("series_uid", None), saved_dict.pop("series_uid", None)
-            )
-        # pop off cod dict for comparison later (it is the most complex)
-        raw_cod = raw_dict.pop("cod")
-        saved_cod = saved_dict.pop("cod")
-        # check remaining dicts (custom tags) are equal
-        self.assertDictEqual(raw_dict, saved_dict)
-        # now do cod dict comparison
-        self.assertEqual(raw_cod.keys(), saved_cod.keys())
-        for instance_uid in raw_cod["instances"].keys():
-            raw_instance = raw_cod["instances"][instance_uid]
-            saved_instance = saved_cod["instances"][instance_uid]
-            self.assertTrue(
-                all(raw_key in saved_instance.keys() for raw_key in raw_instance.keys())
-            )
-            # Handle version differences: v1 has dict metadata, v2 has compressed string
-            raw_version = raw_instance.get("version", "1.0")
-            saved_version = saved_instance.get("version", "1.0")
-            if raw_version == "1.0" and saved_version == "2.0":
-                # v1 → v2 upgrade: metadata is now compressed, skip metadata and version comparison
-                # but verify it's a string
-                self.assertIsInstance(saved_instance["metadata"], str)
-                # Compare all other fields (skip metadata and version)
-                for key in raw_instance.keys():
-                    if key not in ("metadata", "version"):
-                        self.assertEqual(raw_instance[key], saved_instance[key])
-            else:
-                # Same version: compare all fields
-                for key in raw_instance.keys():
-                    self.assertEqual(raw_instance[key], saved_instance[key])
+            # Same version: compare all fields
+            for key in raw_instance.keys():
+                assert raw_instance[key] == saved_instance[key]
 
-    def test_metadata_load(self):
-        """Test that we can properly load metadata from a json file."""
-        with open(
-            os.path.join(self.test_data_dir, "valid_metadata_v1.json"), "rb"
-        ) as f:
-            metadata = SeriesMetadata.from_bytes(f.read())
-        self._assert_load_success(metadata)
 
-    def test_deid_metadata_load(self):
-        """Test that we can properly load de-identified metadata from a json file."""
-        with open(
-            os.path.join(self.test_data_dir, "valid_deid_metadata_v1.json"), "rb"
-        ) as f:
-            metadata = SeriesMetadata.from_bytes(f.read())
-        self._assert_load_success(metadata)
+def test_metadata_load(test_data_dir: str):
+    """Test that we can properly load metadata from a json file."""
+    with open(os.path.join(test_data_dir, "valid_metadata_v1.json"), "rb") as f:
+        metadata = SeriesMetadata.from_bytes(f.read())
+    _assert_load_success(metadata)
 
-    def test_metadata_save(self):
-        """Test that raw_dict_from_json = dict_when_we_load_then_save_again"""
-        # first load the metadata
-        with open(
-            os.path.join(self.test_data_dir, "valid_metadata_v1.json"), "rb"
-        ) as f:
-            raw_bytes = f.read()
-            # save raw dict for comparison
-            raw_dict = json.loads(raw_bytes)
-            saved_dict = SeriesMetadata.from_bytes(raw_bytes).to_dict()
-        self._assert_save_success(raw_dict, saved_dict, is_deid=False)
 
-    def test_deid_metadata_save(self):
-        """Test that DEID raw_dict_from_json = dict_when_we_load_then_save_again"""
-        # first load the metadata
-        with open(
-            os.path.join(self.test_data_dir, "valid_deid_metadata_v1.json"), "rb"
-        ) as f:
-            raw_bytes = f.read()
-            # save raw dict for comparison
-            raw_dict = json.loads(raw_bytes)
-            saved_dict = SeriesMetadata.from_bytes(raw_bytes).to_dict()
-        self._assert_save_success(raw_dict, saved_dict, is_deid=True)
+def test_deid_metadata_load(test_data_dir: str):
+    """Test that we can properly load de-identified metadata from a json file."""
+    with open(os.path.join(test_data_dir, "valid_deid_metadata_v1.json"), "rb") as f:
+        metadata = SeriesMetadata.from_bytes(f.read())
+    _assert_load_success(metadata)
 
-    def test_v2_round_trip(self):
-        """Test that v2 metadata can be loaded and saved correctly."""
-        # Load v1 metadata and save it (will be saved as v2)
-        with open(
-            os.path.join(self.test_data_dir, "valid_metadata_v1.json"), "rb"
-        ) as f:
-            metadata = SeriesMetadata.from_bytes(f.read())
 
-        # Save as v2
-        v2_dict = metadata.to_dict()
+def test_metadata_save(test_data_dir: str):
+    """Test that raw_dict_from_json = dict_when_we_load_then_save_again"""
+    # first load the metadata
+    with open(os.path.join(test_data_dir, "valid_metadata_v1.json"), "rb") as f:
+        raw_bytes = f.read()
+        # save raw dict for comparison
+        raw_dict = json.loads(raw_bytes)
+        saved_dict = SeriesMetadata.from_bytes(raw_bytes).to_dict()
+    _assert_save_success(raw_dict, saved_dict, is_deid=False)
 
-        # Verify it's v2 format
-        for instance_uid, instance_dict in v2_dict["cod"]["instances"].items():
-            self.assertEqual(instance_dict["version"], "2.0")
-            self.assertIsInstance(instance_dict["metadata"], str)
 
-        # Load the v2 dict back
-        reloaded_metadata = SeriesMetadata.from_dict(v2_dict)
+def test_deid_metadata_save(test_data_dir: str):
+    """Test that DEID raw_dict_from_json = dict_when_we_load_then_save_again"""
+    # first load the metadata
+    with open(os.path.join(test_data_dir, "valid_deid_metadata_v1.json"), "rb") as f:
+        raw_bytes = f.read()
+        # save raw dict for comparison
+        raw_dict = json.loads(raw_bytes)
+        saved_dict = SeriesMetadata.from_bytes(raw_bytes).to_dict()
+    _assert_save_success(raw_dict, saved_dict, is_deid=True)
 
-        # Verify we can access metadata (lazy decompression)
-        for instance_uid, instance in reloaded_metadata.instances.items():
-            # Accessing metadata should trigger decompression
-            metadata_dict = instance.metadata
-            self.assertIsInstance(metadata_dict, dict)
-            # Verify we can access a specific tag
-            self.assertIn("00080018", metadata_dict)  # SOPInstanceUID tag
 
-    def test_v1_to_v2_upgrade(self):
-        """Test that v1 metadata is automatically upgraded to v2 when saved."""
-        # Load v1 metadata
-        with open(
-            os.path.join(self.test_data_dir, "valid_metadata_v1.json"), "rb"
-        ) as f:
-            raw_bytes = f.read()
-            raw_dict = json.loads(raw_bytes)
-            metadata = SeriesMetadata.from_bytes(raw_bytes)
+def test_v2_round_trip(test_data_dir: str):
+    """Test that v2 metadata can be loaded and saved correctly."""
+    # Load v1 metadata and save it (will be saved as v2)
+    with open(os.path.join(test_data_dir, "valid_metadata_v1.json"), "rb") as f:
+        metadata = SeriesMetadata.from_bytes(f.read())
 
-        # Verify original is v1
-        for instance_uid, instance_dict in raw_dict["cod"]["instances"].items():
-            self.assertEqual(instance_dict["version"], "1.0")
-            self.assertIsInstance(instance_dict["metadata"], dict)
+    # Save as v2
+    v2_dict = metadata.to_dict()
 
-        # Save (should upgrade to v2)
-        saved_dict = metadata.to_dict()
+    # Verify it's v2 format
+    for instance_uid, instance_dict in v2_dict["cod"]["instances"].items():
+        assert instance_dict["version"] == "2.0"
+        assert isinstance(instance_dict["metadata"], str)
 
-        # Verify saved is v2
-        for instance_uid, instance_dict in saved_dict["cod"]["instances"].items():
-            self.assertEqual(instance_dict["version"], "2.0")
-            self.assertIsInstance(instance_dict["metadata"], str)
+    # Load the v2 dict back
+    reloaded_metadata = SeriesMetadata.from_dict(v2_dict)
 
-        # Verify we can still load and access the metadata
-        reloaded_metadata = SeriesMetadata.from_dict(saved_dict)
-        for instance_uid, instance in reloaded_metadata.instances.items():
-            metadata_dict = instance.metadata
-            self.assertIsInstance(metadata_dict, dict)
-            # Verify data integrity by checking a specific tag
-            original_metadata = raw_dict["cod"]["instances"][instance_uid]["metadata"]
-            self.assertEqual(
-                metadata_dict["00080018"]["Value"],
-                original_metadata["00080018"]["Value"],
-            )
-
-    def test_v2_lazy_decompression(self):
-        """Test that v2 metadata is not decompressed until accessed."""
-        # Load v1 and save as v2
-        with open(
-            os.path.join(self.test_data_dir, "valid_metadata_v1.json"), "rb"
-        ) as f:
-            metadata = SeriesMetadata.from_bytes(f.read())
-        v2_dict = metadata.to_dict()
-        reloaded_metadata = SeriesMetadata.from_dict(v2_dict)
-
-        # Check that metadata is CompressedDicomMetadata (not yet decompressed)
-        instance = list(reloaded_metadata.instances.values())[0]
-        self.assertIsNotNone(instance._dicom_metadata)
-        self.assertIsInstance(instance._dicom_metadata, CompressedDicomMetadata)
-        # Internal state should be a string (not yet decompressed to dict)
-        compressed_metadata = instance._dicom_metadata._dicom_metadata
-        self.assertIsInstance(compressed_metadata, str)
-
-        # Access metadata - should trigger decompression
+    # Verify we can access metadata (lazy decompression)
+    for instance_uid, instance in reloaded_metadata.instances.items():
+        # Accessing metadata should trigger decompression
         metadata_dict = instance.metadata
-        self.assertIsInstance(metadata_dict, dict)
-        uncompressed_metadata = instance._dicom_metadata._dicom_metadata
-        self.assertIsInstance(uncompressed_metadata, dict)
-        # Verify that the compressed metadata is smaller than the uncompressed metadata
-        self.assertLess(
-            len(compressed_metadata), len(json.dumps(uncompressed_metadata))
+        assert isinstance(metadata_dict, dict)
+        # Verify we can access a specific tag
+        assert "00080018" in metadata_dict  # SOPInstanceUID tag
+
+
+def test_v1_to_v2_upgrade(test_data_dir: str):
+    """Test that v1 metadata is automatically upgraded to v2 when saved."""
+    # Load v1 metadata
+    with open(os.path.join(test_data_dir, "valid_metadata_v1.json"), "rb") as f:
+        raw_bytes = f.read()
+        raw_dict = json.loads(raw_bytes)
+        metadata = SeriesMetadata.from_bytes(raw_bytes)
+
+    # Verify original is v1
+    for instance_uid, instance_dict in raw_dict["cod"]["instances"].items():
+        assert instance_dict["version"] == "1.0"
+        assert isinstance(instance_dict["metadata"], dict)
+
+    # Save (should upgrade to v2)
+    saved_dict = metadata.to_dict()
+
+    # Verify saved is v2
+    for instance_uid, instance_dict in saved_dict["cod"]["instances"].items():
+        assert instance_dict["version"] == "2.0"
+        assert isinstance(instance_dict["metadata"], str)
+
+    # Verify we can still load and access the metadata
+    reloaded_metadata = SeriesMetadata.from_dict(saved_dict)
+    for instance_uid, instance in reloaded_metadata.instances.items():
+        metadata_dict = instance.metadata
+        assert isinstance(metadata_dict, dict)
+        # Verify data integrity by checking a specific tag
+        original_metadata = raw_dict["cod"]["instances"][instance_uid]["metadata"]
+        assert (
+            metadata_dict["00080018"]["Value"] == original_metadata["00080018"]["Value"]
         )
 
-    def test_v2_compression_ratio(self):
-        """Test that v2 format provides compression (metadata is smaller as string)."""
-        # Load v1 metadata
-        with open(
-            os.path.join(self.test_data_dir, "valid_metadata_v1.json"), "rb"
-        ) as f:
-            metadata = SeriesMetadata.from_bytes(f.read())
 
-        # Get v1 size
-        v1_dict = metadata.to_dict()
-        # Temporarily change to v1 for comparison
-        for instance_uid in v1_dict["cod"]["instances"]:
-            instance = metadata.instances[instance_uid]
-            instance.to_cod_dict_v1()
-            v2_instance_dict = instance.to_cod_dict_v2()
+def test_v2_lazy_decompression(test_data_dir: str):
+    """Test that v2 metadata is not decompressed until accessed."""
+    # Load v1 and save as v2
+    with open(os.path.join(test_data_dir, "valid_metadata_v1.json"), "rb") as f:
+        metadata = SeriesMetadata.from_bytes(f.read())
+    v2_dict = metadata.to_dict()
+    reloaded_metadata = SeriesMetadata.from_dict(v2_dict)
 
-            # v2 metadata should be a compressed string
-            self.assertIsInstance(v2_instance_dict["metadata"], str)
-            # For this test data, compressed string should exist
-            # (exact size depends on data, but we verify it's a string)
-            self.assertGreater(len(v2_instance_dict["metadata"]), 0)
+    # Check that metadata is CompressedDicomMetadata (not yet decompressed)
+    instance = list(reloaded_metadata.instances.values())[0]
+    assert instance._dicom_metadata is not None
+    assert isinstance(instance._dicom_metadata, CompressedDicomMetadata)
+    # Internal state should be a string (not yet decompressed to dict)
+    compressed_metadata = instance._dicom_metadata._dicom_metadata
+    assert isinstance(compressed_metadata, str)
+
+    # Access metadata - should trigger decompression
+    metadata_dict = instance.metadata
+    assert isinstance(metadata_dict, dict)
+    uncompressed_metadata = instance._dicom_metadata._dicom_metadata
+    assert isinstance(uncompressed_metadata, dict)
+    # Verify that the compressed metadata is smaller than the uncompressed metadata
+    assert len(compressed_metadata) < len(json.dumps(uncompressed_metadata))
+
+
+def test_v2_compression_ratio(test_data_dir: str):
+    """Test that v2 format provides compression (metadata is smaller as string)."""
+    # Load v1 metadata
+    with open(os.path.join(test_data_dir, "valid_metadata_v1.json"), "rb") as f:
+        metadata = SeriesMetadata.from_bytes(f.read())
+
+    # Get v1 size
+    v1_dict = metadata.to_dict()
+    # Temporarily change to v1 for comparison
+    for instance_uid in v1_dict["cod"]["instances"]:
+        instance = metadata.instances[instance_uid]
+        instance.to_cod_dict_v1()
+        v2_instance_dict = instance.to_cod_dict_v2()
+
+        # v2 metadata should be a compressed string
+        assert isinstance(v2_instance_dict["metadata"], str)
+        # For this test data, compressed string should exist
+        # (exact size depends on data, but we verify it's a string)
+        assert len(v2_instance_dict["metadata"]) > 0

--- a/cloud_optimized_dicom/tests/test_pydicom.py
+++ b/cloud_optimized_dicom/tests/test_pydicom.py
@@ -1,13 +1,9 @@
-import unittest
+def test_pydicom_version():
+    """
+    Test pydicom version concurrency - pydicom is 2.3.0 and pydicom3 is 3.1.0
+    """
+    import pydicom
+    import pydicom3
 
-
-class TestPydicom(unittest.TestCase):
-    def test_pydicom_version(self):
-        """
-        Test pydicom version concurrency - pydicom is 2.3.0 and pydicom3 is 3.1.0
-        """
-        import pydicom
-        import pydicom3
-
-        self.assertEqual(pydicom.__version__, "2.3.0")
-        self.assertEqual(pydicom3.__version__, "3.1.0")
+    assert pydicom.__version__ == "2.3.0"
+    assert pydicom3.__version__ == "3.1.0"

--- a/cloud_optimized_dicom/tests/test_thumbnail.py
+++ b/cloud_optimized_dicom/tests/test_thumbnail.py
@@ -1,16 +1,13 @@
 import logging
 import os
 import tempfile
-import unittest
 
-import cv2
 import numpy as np
 import pydicom3
 import pydicom3.encaps
-from google.api_core.client_options import ClientOptions
+import pytest
 from google.cloud import storage
 
-from cloud_optimized_dicom import config
 from cloud_optimized_dicom.cod_object import CODObject
 from cloud_optimized_dicom.instance import Instance
 from cloud_optimized_dicom.series_metadata import SeriesMetadata
@@ -23,6 +20,20 @@ from cloud_optimized_dicom.thumbnail import (
     _convert_frames_to_mp4,
 )
 from cloud_optimized_dicom.utils import delete_uploaded_blobs
+
+THUMBNAIL_DATASTORE_PATH = "gs://siskin-172863-temp/cod_thumbnail_tests/dicomweb"
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _enable_logging():
+    logging.basicConfig(level=logging.INFO)
+    logging.getLogger().setLevel(logging.INFO)
+
+
+@pytest.fixture
+def thumbnail_datastore_path(gcs_client: storage.Client) -> str:
+    delete_uploaded_blobs(gcs_client, [THUMBNAIL_DATASTORE_PATH])
+    return THUMBNAIL_DATASTORE_PATH
 
 
 def ingest_and_generate_thumbnail(
@@ -45,38 +56,33 @@ def ingest_and_generate_thumbnail(
 
 
 def validate_thumbnail(
-    testcls: unittest.TestCase,
     thumbnail: np.ndarray,
     cod_obj: CODObject,
     expected_frame_count: int,
     expected_frame_size: tuple[int, int] = (DEFAULT_SIZE, DEFAULT_SIZE),
     save_thumbnail: bool = False,
+    test_data_dir: str = None,
 ):
-    testcls.assertTrue(
-        len(thumbnail.shape) == 3 or len(thumbnail.shape) == 4,
-        "Thumbnail must be a 3D or 4D array",
-    )
+    assert (
+        len(thumbnail.shape) == 3 or len(thumbnail.shape) == 4
+    ), "Thumbnail must be a 3D or 4D array"
     # 3D array -> jpg -> (H, W, 3); 4D array -> mp4 -> (N, H, W, 3)
     num_frames = thumbnail.shape[0] if len(thumbnail.shape) > 3 else 1
     frame_size = (
         thumbnail.shape[1:3] if len(thumbnail.shape) > 3 else thumbnail.shape[0:2]
     )
-    testcls.assertEqual(
-        num_frames,
-        expected_frame_count,
-        f"Expected {expected_frame_count} frames, got {num_frames}",
-    )
-    testcls.assertEqual(
-        frame_size,
-        expected_frame_size,
-        f"Expected frame size {expected_frame_size}, got {frame_size}",
-    )
+    assert (
+        num_frames == expected_frame_count
+    ), f"Expected {expected_frame_count} frames, got {num_frames}"
+    assert (
+        frame_size == expected_frame_size
+    ), f"Expected frame size {expected_frame_size}, got {frame_size}"
 
     # make sure the thumbnail is not blank (all pixels are same value)
     some_pixel_value = (
         thumbnail[50, 50] if len(thumbnail.shape) == 3 else thumbnail[0, 50, 50]
     )
-    testcls.assertFalse(np.all(thumbnail == some_pixel_value), "Thumbnail is blank")
+    assert not np.all(thumbnail == some_pixel_value), "Thumbnail is blank"
 
     # test the thumbnail coord converter
     instance_uid = list(cod_obj.get_metadata_field("thumbnail")["instances"].keys())[0]
@@ -87,316 +93,342 @@ def validate_thumbnail(
         thumbnail_frame_metadata["anchors"]
     )
     # bigger dimension should be expected_frame_size
-    testcls.assertEqual(max(converter.thmb_w, converter.thmb_h), expected_frame_size[0])
+    assert max(converter.thmb_w, converter.thmb_h) == expected_frame_size[0]
     # aspect ratio should be the same as the original image
-    testcls.assertAlmostEqual(
-        converter.thmb_w / converter.thmb_h,
-        converter.orig_w / converter.orig_h,
-        places=2,
+    assert converter.thmb_w / converter.thmb_h == pytest.approx(
+        converter.orig_w / converter.orig_h, abs=0.005
     )
     # convert point on original image to thumbnail and back
     test_point = (10, 10)
     recovered_point = converter.thumbnail_to_original(
         converter.original_to_thumbnail(test_point)
     )
-    testcls.assertAlmostEqual(recovered_point[0], test_point[0])
-    testcls.assertAlmostEqual(recovered_point[1], test_point[1])
+    assert recovered_point[0] == pytest.approx(test_point[0])
+    assert recovered_point[1] == pytest.approx(test_point[1])
     # save the thumbnail if requested
-    if save_thumbnail:
+    if save_thumbnail and test_data_dir is not None:
         if num_frames == 1:
             _convert_frame_to_jpg(
-                thumbnail, os.path.join(testcls.test_data_dir, f"thumbnail.jpg")
+                thumbnail, os.path.join(test_data_dir, f"thumbnail.jpg")
             )
         else:
             _convert_frames_to_mp4(
-                thumbnail, os.path.join(testcls.test_data_dir, f"thumbnail.mp4")
+                thumbnail, os.path.join(test_data_dir, f"thumbnail.mp4")
             )
 
 
-class TestThumbnail(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        logging.basicConfig(level=logging.INFO)
-        logging.getLogger().setLevel(logging.INFO)
-        cls.test_data_dir = os.path.join(os.path.dirname(__file__), "test_data")
-        cls.project = "gradient-pacs-siskin-172863"
-        cls.client = storage.Client(
-            project=cls.project,
-            client_options=ClientOptions(quota_project_id=cls.project),
-        )
-        cls.datastore_path = "gs://siskin-172863-temp/cod_thumbnail_tests/dicomweb"
+def test_gen_monochrome1(
+    gcs_client: storage.Client,
+    thumbnail_datastore_path: str,
+    test_data_dir: str,
+):
+    """Test thumbnail generation for a single frame DICOM file (MONOCHROME1)"""
+    dicom_path = os.path.join(test_data_dir, "monochrome1.dcm")
+    cod_obj, thumbnail = ingest_and_generate_thumbnail(
+        [dicom_path], thumbnail_datastore_path, gcs_client
+    )
+    validate_thumbnail(thumbnail, cod_obj, expected_frame_count=1)
+    reloaded_metadata = SeriesMetadata.from_bytes(cod_obj._metadata.to_bytes())
+    assert reloaded_metadata.metadata_fields["thumbnail"] is not None
+    assert (
+        reloaded_metadata.metadata_fields["thumbnail"]
+        == cod_obj._metadata.metadata_fields["thumbnail"]
+    )
 
-    def setUp(self):
-        delete_uploaded_blobs(self.client, [self.datastore_path])
 
-    def test_gen_monochrome1(self):
-        """Test thumbnail generation for a single frame DICOM file (MONOCHROME1)"""
-        dicom_path = os.path.join(self.test_data_dir, "monochrome1.dcm")
-        cod_obj, thumbnail = ingest_and_generate_thumbnail(
-            [dicom_path], self.datastore_path, self.client
-        )
-        validate_thumbnail(self, thumbnail, cod_obj, expected_frame_count=1)
-        reloaded_metadata = SeriesMetadata.from_bytes(cod_obj._metadata.to_bytes())
-        self.assertIsNotNone(reloaded_metadata.metadata_fields["thumbnail"])
-        self.assertDictEqual(
-            reloaded_metadata.metadata_fields["thumbnail"],
-            cod_obj._metadata.metadata_fields["thumbnail"],
-        )
+def test_gen_monochrome2(
+    gcs_client: storage.Client,
+    thumbnail_datastore_path: str,
+    test_data_dir: str,
+):
+    """Test thumbnail generation for a single frame DICOM file (MONOCHROME2)"""
+    dicom_path = os.path.join(test_data_dir, "monochrome2.dcm")
+    cod_obj, thumbnail = ingest_and_generate_thumbnail(
+        [dicom_path], thumbnail_datastore_path, gcs_client
+    )
+    validate_thumbnail(thumbnail, cod_obj, expected_frame_count=1)
 
-    def test_gen_monochrome2(self):
-        """Test thumbnail generation for a single frame DICOM file (MONOCHROME2)"""
-        dicom_path = os.path.join(self.test_data_dir, "monochrome2.dcm")
-        cod_obj, thumbnail = ingest_and_generate_thumbnail(
-            [dicom_path], self.datastore_path, self.client
-        )
-        validate_thumbnail(self, thumbnail, cod_obj, expected_frame_count=1)
 
-    def test_gen_mp4_mixed_phot_interp(self):
-        """Test thumbnail generation for a series of DICOM files with different photometric interpretations (YBR_RCT and MONOCHROME2)"""
-        series_folder = os.path.join(self.test_data_dir, "series")
-        dicom_paths = [
-            os.path.join(series_folder, f)
-            for f in os.listdir(series_folder)
-            if f.endswith(".dcm")
-        ]
-        cod_obj, thumbnail = ingest_and_generate_thumbnail(
-            dicom_paths, self.datastore_path, self.client
-        )
-        validate_thumbnail(self, thumbnail, cod_obj, expected_frame_count=10)
+def test_gen_mp4_mixed_phot_interp(
+    gcs_client: storage.Client,
+    thumbnail_datastore_path: str,
+    test_data_dir: str,
+):
+    """Test thumbnail generation for a series of DICOM files with different photometric interpretations (YBR_RCT and MONOCHROME2)"""
+    series_folder = os.path.join(test_data_dir, "series")
+    dicom_paths = [
+        os.path.join(series_folder, f)
+        for f in os.listdir(series_folder)
+        if f.endswith(".dcm")
+    ]
+    cod_obj, thumbnail = ingest_and_generate_thumbnail(
+        dicom_paths, thumbnail_datastore_path, gcs_client
+    )
+    validate_thumbnail(thumbnail, cod_obj, expected_frame_count=10)
 
-    def test_gen_mp4_ybr_rct_multiframe(self):
-        """Test thumbnail generation for a multiframe DICOM file (YBR_RCT)"""
-        multiframe_path = os.path.join(self.test_data_dir, "ybr_rct_multiframe.dcm")
-        cod_obj, thumbnail = ingest_and_generate_thumbnail(
-            [multiframe_path], self.datastore_path, self.client
-        )
-        validate_thumbnail(self, thumbnail, cod_obj, expected_frame_count=78)
-        reloaded_metadata = SeriesMetadata.from_bytes(cod_obj._metadata.to_bytes())
-        self.assertIsNotNone(reloaded_metadata.metadata_fields["thumbnail"])
-        self.assertDictEqual(
-            reloaded_metadata.metadata_fields["thumbnail"],
-            cod_obj._metadata.metadata_fields["thumbnail"],
-        )
 
-    def test_custom_thumbnail_size(self):
-        """Test thumbnail generation for a single frame DICOM file (MONOCHROME1) with a non-default thumbnail size"""
-        # single frame
-        dicom_path = os.path.join(self.test_data_dir, "monochrome1.dcm")
-        cod_obj, thumbnail = ingest_and_generate_thumbnail(
-            [dicom_path], self.datastore_path, self.client, thumbnail_size=256
-        )
-        validate_thumbnail(
-            self,
-            thumbnail,
-            cod_obj,
-            expected_frame_count=1,
-            expected_frame_size=(256, 256),
-        )
-        # multiframe
-        multiframe_path = os.path.join(self.test_data_dir, "ybr_rct_multiframe.dcm")
-        cod_obj, thumbnail = ingest_and_generate_thumbnail(
-            [multiframe_path], self.datastore_path, self.client, thumbnail_size=256
-        )
-        validate_thumbnail(
-            self,
-            thumbnail,
-            cod_obj,
-            expected_frame_count=78,
-            expected_frame_size=(256, 256),
-        )
+def test_gen_mp4_ybr_rct_multiframe(
+    gcs_client: storage.Client,
+    thumbnail_datastore_path: str,
+    test_data_dir: str,
+):
+    """Test thumbnail generation for a multiframe DICOM file (YBR_RCT)"""
+    multiframe_path = os.path.join(test_data_dir, "ybr_rct_multiframe.dcm")
+    cod_obj, thumbnail = ingest_and_generate_thumbnail(
+        [multiframe_path], thumbnail_datastore_path, gcs_client
+    )
+    validate_thumbnail(thumbnail, cod_obj, expected_frame_count=78)
+    reloaded_metadata = SeriesMetadata.from_bytes(cod_obj._metadata.to_bytes())
+    assert reloaded_metadata.metadata_fields["thumbnail"] is not None
+    assert (
+        reloaded_metadata.metadata_fields["thumbnail"]
+        == cod_obj._metadata.metadata_fields["thumbnail"]
+    )
 
-    def test_sync_and_fetch(self):
-        """Test thumbnail generation and sync"""
-        # create and sync thumbnail
-        instance = Instance(
-            dicom_uri=os.path.join(self.test_data_dir, "monochrome1.dcm")
-        )
+
+def test_custom_thumbnail_size(
+    gcs_client: storage.Client,
+    thumbnail_datastore_path: str,
+    test_data_dir: str,
+):
+    """Test thumbnail generation for a single frame DICOM file (MONOCHROME1) with a non-default thumbnail size"""
+    # single frame
+    dicom_path = os.path.join(test_data_dir, "monochrome1.dcm")
+    cod_obj, thumbnail = ingest_and_generate_thumbnail(
+        [dicom_path], thumbnail_datastore_path, gcs_client, thumbnail_size=256
+    )
+    validate_thumbnail(
+        thumbnail,
+        cod_obj,
+        expected_frame_count=1,
+        expected_frame_size=(256, 256),
+    )
+    # multiframe
+    multiframe_path = os.path.join(test_data_dir, "ybr_rct_multiframe.dcm")
+    cod_obj, thumbnail = ingest_and_generate_thumbnail(
+        [multiframe_path], thumbnail_datastore_path, gcs_client, thumbnail_size=256
+    )
+    validate_thumbnail(
+        thumbnail,
+        cod_obj,
+        expected_frame_count=78,
+        expected_frame_size=(256, 256),
+    )
+
+
+def test_sync_and_fetch(
+    gcs_client: storage.Client,
+    thumbnail_datastore_path: str,
+    test_data_dir: str,
+):
+    """Test thumbnail generation and sync"""
+    # create and sync thumbnail
+    instance = Instance(dicom_uri=os.path.join(test_data_dir, "monochrome1.dcm"))
+    with CODObject(
+        datastore_path=thumbnail_datastore_path,
+        client=gcs_client,
+        study_uid=instance.study_uid(),
+        series_uid=instance.series_uid(),
+        mode="w",
+    ) as cod_obj:
+        cod_obj.append([instance])
+        cod_obj.get_thumbnail()
+        # sync happens automatically on context exit
+    # with a new cod object, fetch and validate thumbnail
+    with CODObject(
+        datastore_path=thumbnail_datastore_path,
+        client=gcs_client,
+        study_uid=instance.study_uid(),
+        series_uid=instance.series_uid(),
+        mode="r",
+    ) as cod_obj:
+        # thumbnail is not synced - it exists in datastore, but we haven't pulled it
+        assert not cod_obj._thumbnail_synced
+        thumbnail = cod_obj.get_thumbnail()
+        # thumbnail is now synced
+        assert cod_obj._thumbnail_synced
+        validate_thumbnail(thumbnail, cod_obj, expected_frame_count=1)
+
+
+def test_update_existing_thumbnail(
+    gcs_client: storage.Client,
+    thumbnail_datastore_path: str,
+    test_data_dir: str,
+):
+    """Test that updating an existing thumbnail works"""
+    instance_a = Instance(
+        dicom_uri=os.path.join(
+            test_data_dir,
+            "series",
+            "1.2.826.0.1.3680043.8.498.22997958494980951977704130269567444795.dcm",
+        ),
+        uid_hash_func=example_hash_function,
+    )
+    with CODObject(
+        datastore_path=thumbnail_datastore_path,
+        client=gcs_client,
+        study_uid=instance_a.hashed_study_uid(),
+        series_uid=instance_a.hashed_series_uid(),
+        hashed_uids=True,
+        mode="w",
+    ) as cod_obj:
+        cod_obj.append([instance_a])
+        thumbnail = cod_obj.get_thumbnail()
+        validate_thumbnail(thumbnail, cod_obj, expected_frame_count=1)
+        # sync happens automatically on context exit
+    instance_b = Instance(
+        dicom_uri=os.path.join(
+            test_data_dir,
+            "series",
+            "1.2.826.0.1.3680043.8.498.28109707839310833322020505651875585013.dcm",
+        ),
+        uid_hash_func=example_hash_function,
+    )
+    with CODObject(
+        datastore_path=thumbnail_datastore_path,
+        client=gcs_client,
+        study_uid=instance_b.hashed_study_uid(),
+        series_uid=instance_b.hashed_series_uid(),
+        hashed_uids=True,
+        mode="a",
+    ) as cod_obj:
+        cod_obj.append([instance_b])
+        thumbnail = cod_obj.get_thumbnail()
+        validate_thumbnail(thumbnail, cod_obj, expected_frame_count=2)
+
+
+def test_regen_missing_thumbnail(
+    gcs_client: storage.Client,
+    thumbnail_datastore_path: str,
+    test_data_dir: str,
+):
+    """Test that we can regenerate a missing thumbnail"""
+    instance = Instance(dicom_uri=os.path.join(test_data_dir, "monochrome1.dcm"))
+    with CODObject(
+        datastore_path=thumbnail_datastore_path,
+        client=gcs_client,
+        study_uid=instance.study_uid(),
+        series_uid=instance.series_uid(),
+        mode="w",
+    ) as cod_obj:
+        cod_obj.append([instance])
+        cod_obj.get_thumbnail()
+        cod_obj._sync()
+        thumbnail_uri = cod_obj.get_metadata_field("thumbnail")["uri"]
+    # delete the thumbnail
+    thumbnail_blob = storage.Blob.from_string(thumbnail_uri, client=gcs_client)
+    thumbnail_blob.delete()
+    assert not thumbnail_blob.exists()
+    with CODObject(
+        datastore_path=thumbnail_datastore_path,
+        client=gcs_client,
+        study_uid=instance.study_uid(),
+        series_uid=instance.series_uid(),
+        mode="a",
+        sync_on_exit=False,
+    ) as cod_obj:
+        # should get ValueError if we try to get the missing thumbnail without generating
+        with pytest.raises(ValueError):
+            cod_obj.get_thumbnail(generate_if_missing=False)
+        # should get the thumbnail if we generate it
+        thumbnail = cod_obj.get_thumbnail(generate_if_missing=True)
+        validate_thumbnail(thumbnail, cod_obj, expected_frame_count=1)
+
+
+def test_get_instance_slice(
+    gcs_client: storage.Client,
+    thumbnail_datastore_path: str,
+    test_data_dir: str,
+):
+    """Test that we can get a slice of the thumbnail for a given instance"""
+    # make sure we can get a single img slice from a series thumbnail
+    series_folder = os.path.join(test_data_dir, "series")
+    dicom_paths = [
+        os.path.join(series_folder, f)
+        for f in os.listdir(series_folder)
+        if f.endswith(".dcm")
+    ]
+    cod_obj, thumbnail = ingest_and_generate_thumbnail(
+        dicom_paths, thumbnail_datastore_path, gcs_client
+    )
+    validate_thumbnail(thumbnail, cod_obj, expected_frame_count=10)
+    some_instance_uid = cod_obj.get_instance_by_index(5).instance_uid()
+    thumbnail_slice = cod_obj.get_thumbnail(instance_uid=some_instance_uid)
+    validate_thumbnail(thumbnail_slice, cod_obj, expected_frame_count=1)
+
+    # make sure that getting a slice of a series with a single multiframe returns the same as the overall thumbnail
+    multiframe_path = os.path.join(test_data_dir, "ybr_rct_multiframe.dcm")
+    cod_obj, thumbnail = ingest_and_generate_thumbnail(
+        [multiframe_path], thumbnail_datastore_path, gcs_client
+    )
+    validate_thumbnail(thumbnail, cod_obj, expected_frame_count=78)
+    some_instance_uid = cod_obj.get_instance_by_index(0).instance_uid()
+    thumbnail_slice = cod_obj.get_thumbnail(instance_uid=some_instance_uid)
+    assert np.all(thumbnail_slice == thumbnail)
+
+
+def test_get_instance_by_thumbnail_index(
+    gcs_client: storage.Client,
+    thumbnail_datastore_path: str,
+    test_data_dir: str,
+):
+    """Test that we can get an instance by thumbnail index"""
+    # make sure we can get a single img slice from a series thumbnail
+    series_folder = os.path.join(test_data_dir, "series")
+    dicom_paths = [
+        os.path.join(series_folder, f)
+        for f in os.listdir(series_folder)
+        if f.endswith(".dcm")
+    ]
+    cod_obj, thumbnail = ingest_and_generate_thumbnail(
+        dicom_paths, thumbnail_datastore_path, gcs_client
+    )
+    validate_thumbnail(thumbnail, cod_obj, expected_frame_count=10)
+    # because this series is 10 single frame instances, we expect the check below to pass
+    instance_retrieved_by_index = cod_obj.get_instance_by_index(5)
+    instance_retrieved_by_thumbnail_index = cod_obj.get_instance_by_thumbnail_index(5)
+    assert instance_retrieved_by_index == instance_retrieved_by_thumbnail_index
+
+
+def test_series_missing_pixel_data_error(
+    gcs_client: storage.Client,
+    thumbnail_datastore_path: str,
+    test_data_dir: str,
+):
+    """Test that SeriesMissingPixelDataError is raised when series has no pixel data"""
+    # Create a DICOM file without pixel data by reading an existing file
+    # and removing the pixel data
+    dicom_path = os.path.join(test_data_dir, "monochrome1.dcm")
+    ds = pydicom3.dcmread(dicom_path)
+
+    # Remove pixel data
+    if hasattr(ds, "PixelData"):
+        delattr(ds, "PixelData")
+
+    # Save the modified DICOM to a temporary file
+    with tempfile.NamedTemporaryFile(suffix=".dcm", delete=False) as tmp_file:
+        temp_dicom_path = tmp_file.name
+        ds.save_as(temp_dicom_path)
+
+    try:
+        # Create instance and COD object
+        instance = Instance(dicom_uri=temp_dicom_path)
         with CODObject(
-            datastore_path=self.datastore_path,
-            client=self.client,
+            datastore_path=thumbnail_datastore_path,
+            client=gcs_client,
             study_uid=instance.study_uid(),
             series_uid=instance.series_uid(),
             mode="w",
-        ) as cod_obj:
-            cod_obj.append([instance])
-            cod_obj.get_thumbnail()
-            # sync happens automatically on context exit
-        # with a new cod object, fetch and validate thumbnail
-        with CODObject(
-            datastore_path=self.datastore_path,
-            client=self.client,
-            study_uid=instance.study_uid(),
-            series_uid=instance.series_uid(),
-            mode="r",
-        ) as cod_obj:
-            # thumbnail is not synced - it exists in datastore, but we haven't pulled it
-            self.assertFalse(cod_obj._thumbnail_synced)
-            thumbnail = cod_obj.get_thumbnail()
-            # thumbnail is now synced
-            self.assertTrue(cod_obj._thumbnail_synced)
-            validate_thumbnail(self, thumbnail, cod_obj, expected_frame_count=1)
-
-    def test_update_existing_thumbnail(self):
-        """Test that updating an existing thumbnail works"""
-        instance_a = Instance(
-            dicom_uri=os.path.join(
-                self.test_data_dir,
-                "series",
-                "1.2.826.0.1.3680043.8.498.22997958494980951977704130269567444795.dcm",
-            ),
-            uid_hash_func=example_hash_function,
-        )
-        with CODObject(
-            datastore_path=self.datastore_path,
-            client=self.client,
-            study_uid=instance_a.hashed_study_uid(),
-            series_uid=instance_a.hashed_series_uid(),
-            hashed_uids=True,
-            mode="w",
-        ) as cod_obj:
-            cod_obj.append([instance_a])
-            thumbnail = cod_obj.get_thumbnail()
-            validate_thumbnail(self, thumbnail, cod_obj, expected_frame_count=1)
-            # sync happens automatically on context exit
-        instance_b = Instance(
-            dicom_uri=os.path.join(
-                self.test_data_dir,
-                "series",
-                "1.2.826.0.1.3680043.8.498.28109707839310833322020505651875585013.dcm",
-            ),
-            uid_hash_func=example_hash_function,
-        )
-        with CODObject(
-            datastore_path=self.datastore_path,
-            client=self.client,
-            study_uid=instance_b.hashed_study_uid(),
-            series_uid=instance_b.hashed_series_uid(),
-            hashed_uids=True,
-            mode="a",
-        ) as cod_obj:
-            cod_obj.append([instance_b])
-            thumbnail = cod_obj.get_thumbnail()
-            validate_thumbnail(self, thumbnail, cod_obj, expected_frame_count=2)
-
-    def test_regen_missing_thumbnail(self):
-        """Test that we can regenerate a missing thumbnail"""
-        instance = Instance(
-            dicom_uri=os.path.join(self.test_data_dir, "monochrome1.dcm")
-        )
-        with CODObject(
-            datastore_path=self.datastore_path,
-            client=self.client,
-            study_uid=instance.study_uid(),
-            series_uid=instance.series_uid(),
-            mode="w",
-        ) as cod_obj:
-            cod_obj.append([instance])
-            cod_obj.get_thumbnail()
-            cod_obj._sync()
-            thumbnail_uri = cod_obj.get_metadata_field("thumbnail")["uri"]
-        # delete the thumbnail
-        thumbnail_blob = storage.Blob.from_string(thumbnail_uri, client=self.client)
-        thumbnail_blob.delete()
-        self.assertFalse(thumbnail_blob.exists())
-        with CODObject(
-            datastore_path=self.datastore_path,
-            client=self.client,
-            study_uid=instance.study_uid(),
-            series_uid=instance.series_uid(),
-            mode="a",
             sync_on_exit=False,
         ) as cod_obj:
-            # should get ValueError if we try to get the missing thumbnail without generating
-            with self.assertRaises(ValueError):
-                cod_obj.get_thumbnail(generate_if_missing=False)
-            # should get the thumbnail if we generate it
-            thumbnail = cod_obj.get_thumbnail(generate_if_missing=True)
-            validate_thumbnail(self, thumbnail, cod_obj, expected_frame_count=1)
+            cod_obj.append([instance])
+            # Attempting to get thumbnail should raise SeriesMissingPixelDataError
+            with pytest.raises(SeriesMissingPixelDataError) as exc_info:
+                cod_obj.get_thumbnail()
 
-    def test_get_instance_slice(self):
-        """Test that we can get a slice of the thumbnail for a given instance"""
-        # make sure we can get a single img slice from a series thumbnail
-        series_folder = os.path.join(self.test_data_dir, "series")
-        dicom_paths = [
-            os.path.join(series_folder, f)
-            for f in os.listdir(series_folder)
-            if f.endswith(".dcm")
-        ]
-        cod_obj, thumbnail = ingest_and_generate_thumbnail(
-            dicom_paths, self.datastore_path, self.client
-        )
-        validate_thumbnail(self, thumbnail, cod_obj, expected_frame_count=10)
-        some_instance_uid = cod_obj.get_instance_by_index(5).instance_uid()
-        thumbnail_slice = cod_obj.get_thumbnail(instance_uid=some_instance_uid)
-        validate_thumbnail(self, thumbnail_slice, cod_obj, expected_frame_count=1)
-
-        # make sure that getting a slice of a series with a single multiframe returns the same as the overall thumbnail
-        multiframe_path = os.path.join(self.test_data_dir, "ybr_rct_multiframe.dcm")
-        cod_obj, thumbnail = ingest_and_generate_thumbnail(
-            [multiframe_path], self.datastore_path, self.client
-        )
-        validate_thumbnail(self, thumbnail, cod_obj, expected_frame_count=78)
-        some_instance_uid = cod_obj.get_instance_by_index(0).instance_uid()
-        thumbnail_slice = cod_obj.get_thumbnail(instance_uid=some_instance_uid)
-        self.assertTrue(np.all(thumbnail_slice == thumbnail))
-
-    def test_get_instance_by_thumbnail_index(self):
-        """Test that we can get an instance by thumbnail index"""
-        # make sure we can get a single img slice from a series thumbnail
-        series_folder = os.path.join(self.test_data_dir, "series")
-        dicom_paths = [
-            os.path.join(series_folder, f)
-            for f in os.listdir(series_folder)
-            if f.endswith(".dcm")
-        ]
-        cod_obj, thumbnail = ingest_and_generate_thumbnail(
-            dicom_paths, self.datastore_path, self.client
-        )
-        validate_thumbnail(self, thumbnail, cod_obj, expected_frame_count=10)
-        # because this series is 10 single frame instances, we expect the check below to pass
-        instance_retrieved_by_index = cod_obj.get_instance_by_index(5)
-        instance_retrieved_by_thumbnail_index = cod_obj.get_instance_by_thumbnail_index(
-            5
-        )
-        self.assertEqual(
-            instance_retrieved_by_index, instance_retrieved_by_thumbnail_index
-        )
-
-    def test_series_missing_pixel_data_error(self):
-        """Test that SeriesMissingPixelDataError is raised when series has no pixel data"""
-        # Create a DICOM file without pixel data by reading an existing file
-        # and removing the pixel data
-        dicom_path = os.path.join(self.test_data_dir, "monochrome1.dcm")
-        ds = pydicom3.dcmread(dicom_path)
-
-        # Remove pixel data
-        if hasattr(ds, "PixelData"):
-            delattr(ds, "PixelData")
-
-        # Save the modified DICOM to a temporary file
-        with tempfile.NamedTemporaryFile(suffix=".dcm", delete=False) as tmp_file:
-            temp_dicom_path = tmp_file.name
-            ds.save_as(temp_dicom_path)
-
-        try:
-            # Create instance and COD object
-            instance = Instance(dicom_uri=temp_dicom_path)
-            with CODObject(
-                datastore_path=self.datastore_path,
-                client=self.client,
-                study_uid=instance.study_uid(),
-                series_uid=instance.series_uid(),
-                mode="w",
-                sync_on_exit=False,
-            ) as cod_obj:
-                cod_obj.append([instance])
-                # Attempting to get thumbnail should raise SeriesMissingPixelDataError
-                with self.assertRaises(SeriesMissingPixelDataError) as context:
-                    cod_obj.get_thumbnail()
-
-                # Verify the error message contains helpful info
-                self.assertIn("pixel data", str(context.exception))
-        finally:
-            # Clean up temporary file
-            if os.path.exists(temp_dicom_path):
-                os.remove(temp_dicom_path)
+            # Verify the error message contains helpful info
+            assert "pixel data" in str(exc_info.value)
+    finally:
+        # Clean up temporary file
+        if os.path.exists(temp_dicom_path):
+            os.remove(temp_dicom_path)

--- a/cloud_optimized_dicom/tests/test_truncate.py
+++ b/cloud_optimized_dicom/tests/test_truncate.py
@@ -1,164 +1,157 @@
 import logging
 import os
 import tarfile
-import unittest
 
-from google.api_core.client_options import ClientOptions
+import pytest
 from google.cloud import storage
 
 from cloud_optimized_dicom.cod_object import CODObject
 from cloud_optimized_dicom.instance import Instance
-from cloud_optimized_dicom.utils import delete_uploaded_blobs
 
 
-class TestTruncate(unittest.TestCase):
+@pytest.fixture(autouse=True)
+def _enable_logging():
+    logging.basicConfig(level=logging.INFO)
 
-    @classmethod
-    def setUpClass(cls):
-        cls.test_data_dir = os.path.join(os.path.dirname(__file__), "test_data")
-        cls.client = storage.Client(
-            project="gradient-pacs-siskin-172863",
-            client_options=ClientOptions(
-                quota_project_id="gradient-pacs-siskin-172863"
-            ),
+
+def test_truncate(
+    gcs_client: storage.Client,
+    datastore_path: str,
+    test_data_dir: str,
+):
+    """
+    Test that a cod object can be successfully truncated using mode="w" + append().
+    """
+    instance1 = Instance(
+        dicom_uri=os.path.join(
+            test_data_dir,
+            "series",
+            "1.2.826.0.1.3680043.8.498.22997958494980951977704130269567444795.dcm",
         )
-        cls.datastore_path = "gs://siskin-172863-temp/cod_tests/dicomweb"
-        logging.basicConfig(level=logging.INFO)
+    )
+    instance2 = Instance(
+        dicom_uri=os.path.join(
+            test_data_dir,
+            "series",
+            "1.2.826.0.1.3680043.8.498.28109707839310833322020505651875585013.dcm",
+        )
+    )
+    cod_obj = CODObject(
+        datastore_path=datastore_path,
+        client=gcs_client,
+        study_uid=instance1.study_uid(),
+        series_uid=instance1.series_uid(),
+        mode="w",
+        sync_on_exit=False,
+    )
+    append_result = cod_obj.append(instances=[instance1])
+    assert len(append_result.new) == 1
+    # Truncate by wiping and rebuilding with mode="w" + append()
+    cod_obj._wipe_local()
+    truncate_result = cod_obj.append(instances=[instance2])
+    assert len(truncate_result.new) == 1
+    assert truncate_result.new[0] == instance2
+    # cod object should ONLY contain the new instance
+    assert list(cod_obj.get_metadata().instances.values()) == [instance2]
+    with tarfile.open(cod_obj.tar_file_path, "r") as tar:
+        assert len(tar.getmembers()) == 1
+        assert tar.getmembers()[0].name == f"instances/{instance2.instance_uid()}.dcm"
 
-    def setUp(self):
-        # ensure clean test directory prior to test start
-        delete_uploaded_blobs(self.client, [self.datastore_path])
 
-    def test_truncate(self):
-        """
-        Test that a cod object can be successfully truncated using mode="w" + append().
-        """
-        instance1 = Instance(
-            dicom_uri=os.path.join(
-                self.test_data_dir,
-                "series",
-                "1.2.826.0.1.3680043.8.498.22997958494980951977704130269567444795.dcm",
-            )
+def test_truncate_remote(
+    gcs_client: storage.Client,
+    datastore_path: str,
+    test_data_dir: str,
+):
+    """
+    Test that a cod object can be successfully truncated from a remote cod object using mode="w" + append().
+    """
+    instance1 = Instance(
+        dicom_uri=os.path.join(
+            test_data_dir,
+            "series",
+            "1.2.826.0.1.3680043.8.498.22997958494980951977704130269567444795.dcm",
         )
-        instance2 = Instance(
-            dicom_uri=os.path.join(
-                self.test_data_dir,
-                "series",
-                "1.2.826.0.1.3680043.8.498.28109707839310833322020505651875585013.dcm",
-            )
+    )
+    instance2 = Instance(
+        dicom_uri=os.path.join(
+            test_data_dir,
+            "series",
+            "1.2.826.0.1.3680043.8.498.28109707839310833322020505651875585013.dcm",
         )
-        cod_obj = CODObject(
-            datastore_path=self.datastore_path,
-            client=self.client,
-            study_uid=instance1.study_uid(),
-            series_uid=instance1.series_uid(),
-            mode="w",
-            sync_on_exit=False,
-        )
+    )
+    with CODObject(
+        datastore_path=datastore_path,
+        client=gcs_client,
+        study_uid=instance1.study_uid(),
+        series_uid=instance1.series_uid(),
+        mode="w",
+    ) as cod_obj:
         append_result = cod_obj.append(instances=[instance1])
-        self.assertEqual(len(append_result.new), 1)
-        # Truncate by wiping and rebuilding with mode="w" + append()
-        cod_obj._wipe_local()
+        assert len(append_result.new) == 1
+        # sync happens automatically on context exit
+
+    # Truncate by creating new CODObject with mode="w" and appending desired instances
+    # mode="w" will overwrite the remote tar/metadata on sync
+    with CODObject(
+        datastore_path=datastore_path,
+        client=gcs_client,
+        study_uid=instance1.study_uid(),
+        series_uid=instance1.series_uid(),
+        mode="w",
+    ) as cod_obj:
         truncate_result = cod_obj.append(instances=[instance2])
-        self.assertEqual(len(truncate_result.new), 1)
-        self.assertEqual(truncate_result.new[0], instance2)
+        assert len(truncate_result.new) == 1
+        assert truncate_result.new[0] == instance2
         # cod object should ONLY contain the new instance
-        self.assertEqual(list(cod_obj.get_metadata().instances.values()), [instance2])
-        with tarfile.open(cod_obj.tar_file_path, "r") as tar:
-            self.assertEqual(len(tar.getmembers()), 1)
-            self.assertEqual(
-                tar.getmembers()[0].name, f"instances/{instance2.instance_uid()}.dcm"
-            )
+        assert list(cod_obj.get_metadata().instances.values()) == [instance2]
 
-    def test_truncate_remote(self):
-        """
-        Test that a cod object can be successfully truncated from a remote cod object using mode="w" + append().
-        """
-        instance1 = Instance(
-            dicom_uri=os.path.join(
-                self.test_data_dir,
-                "series",
-                "1.2.826.0.1.3680043.8.498.22997958494980951977704130269567444795.dcm",
-            )
-        )
-        instance2 = Instance(
-            dicom_uri=os.path.join(
-                self.test_data_dir,
-                "series",
-                "1.2.826.0.1.3680043.8.498.28109707839310833322020505651875585013.dcm",
-            )
-        )
-        with CODObject(
-            datastore_path=self.datastore_path,
-            client=self.client,
-            study_uid=instance1.study_uid(),
-            series_uid=instance1.series_uid(),
-            mode="w",
-        ) as cod_obj:
-            append_result = cod_obj.append(instances=[instance1])
-            self.assertEqual(len(append_result.new), 1)
-            # sync happens automatically on context exit
 
-        # Truncate by creating new CODObject with mode="w" and appending desired instances
-        # mode="w" will overwrite the remote tar/metadata on sync
-        with CODObject(
-            datastore_path=self.datastore_path,
-            client=self.client,
-            study_uid=instance1.study_uid(),
-            series_uid=instance1.series_uid(),
-            mode="w",
-        ) as cod_obj:
-            truncate_result = cod_obj.append(instances=[instance2])
-            self.assertEqual(len(truncate_result.new), 1)
-            self.assertEqual(truncate_result.new[0], instance2)
-            # cod object should ONLY contain the new instance
-            self.assertEqual(
-                list(cod_obj.get_metadata().instances.values()), [instance2]
-            )
-
-    def test_truncate_preexisting(self):
-        """
-        Test that a cod object can be successfully truncated with preexisting instances using mode="w" + append().
-        """
-        instance1 = Instance(
-            dicom_uri=os.path.join(
-                self.test_data_dir,
-                "series",
-                "1.2.826.0.1.3680043.8.498.22997958494980951977704130269567444795.dcm",
-            )
+def test_truncate_preexisting(
+    gcs_client: storage.Client,
+    datastore_path: str,
+    test_data_dir: str,
+):
+    """
+    Test that a cod object can be successfully truncated with preexisting instances using mode="w" + append().
+    """
+    instance1 = Instance(
+        dicom_uri=os.path.join(
+            test_data_dir,
+            "series",
+            "1.2.826.0.1.3680043.8.498.22997958494980951977704130269567444795.dcm",
         )
-        instance2 = Instance(
-            dicom_uri=os.path.join(
-                self.test_data_dir,
-                "series",
-                "1.2.826.0.1.3680043.8.498.28109707839310833322020505651875585013.dcm",
-            )
+    )
+    instance2 = Instance(
+        dicom_uri=os.path.join(
+            test_data_dir,
+            "series",
+            "1.2.826.0.1.3680043.8.498.28109707839310833322020505651875585013.dcm",
         )
-        cod_obj = CODObject(
-            datastore_path=self.datastore_path,
-            client=self.client,
-            study_uid=instance1.study_uid(),
-            series_uid=instance1.series_uid(),
-            mode="w",
-            sync_on_exit=False,
+    )
+    cod_obj = CODObject(
+        datastore_path=datastore_path,
+        client=gcs_client,
+        study_uid=instance1.study_uid(),
+        series_uid=instance1.series_uid(),
+        mode="w",
+        sync_on_exit=False,
+    )
+    append_result = cod_obj.append(instances=[instance1, instance2])
+    assert len(append_result.new) == 2
+    # Truncate by wiping and rebuilding with mode="w" + append()
+    # Create a fresh instance2 from the original file path since the old one
+    # now points to the tar location which will be deleted by _wipe_local()
+    cod_obj._wipe_local()
+    instance2_fresh = Instance(
+        dicom_uri=os.path.join(
+            test_data_dir,
+            "series",
+            "1.2.826.0.1.3680043.8.498.28109707839310833322020505651875585013.dcm",
         )
-        append_result = cod_obj.append(instances=[instance1, instance2])
-        self.assertEqual(len(append_result.new), 2)
-        # Truncate by wiping and rebuilding with mode="w" + append()
-        # Create a fresh instance2 from the original file path since the old one
-        # now points to the tar location which will be deleted by _wipe_local()
-        cod_obj._wipe_local()
-        instance2_fresh = Instance(
-            dicom_uri=os.path.join(
-                self.test_data_dir,
-                "series",
-                "1.2.826.0.1.3680043.8.498.28109707839310833322020505651875585013.dcm",
-            )
-        )
-        truncate_result = cod_obj.append(instances=[instance2_fresh])
-        self.assertEqual(len(truncate_result.new), 1)
-        self.assertEqual(truncate_result.new[0], instance2_fresh)
-        # cod object should ONLY contain the new instance
-        self.assertEqual(
-            list(cod_obj.get_metadata().instances.values()), [instance2_fresh]
-        )
+    )
+    truncate_result = cod_obj.append(instances=[instance2_fresh])
+    assert len(truncate_result.new) == 1
+    assert truncate_result.new[0] == instance2_fresh
+    # cod object should ONLY contain the new instance
+    assert list(cod_obj.get_metadata().instances.values()) == [instance2_fresh]

--- a/cloud_optimized_dicom/tests/test_virtual_file.py
+++ b/cloud_optimized_dicom/tests/test_virtual_file.py
@@ -1,130 +1,147 @@
 import io
-import unittest
+
+import pytest
 
 from cloud_optimized_dicom.virtual_file import VirtualFile
 
 
-class TestVirtualFile(unittest.TestCase):
-    def setUp(self):
-        # Create a mock file with content "0123456789"
-        self.mock_content = b"0123456789"
-        self.master_file = io.BytesIO(self.mock_content)
-        # Create virtual file from positions 2-7 (content should be "23456")
-        self.virtual_file = VirtualFile(self.master_file, 2, 7)
-
-    def tearDown(self):
-        self.master_file.close()
-
-    # Read tests
-    def test_read_all(self):
-        """Test reading entire virtual file"""
-        self.assertEqual(self.virtual_file.read(), b"23456")
-
-    def test_read_partial(self):
-        """Test reading specific number of bytes"""
-        self.assertEqual(self.virtual_file.read(2), b"23")
-        self.assertEqual(self.virtual_file.read(2), b"45")
-
-    def test_read_beyond_bounds(self):
-        """Test reading more bytes than available"""
-        self.assertEqual(self.virtual_file.read(1000), b"23456")
-
-    def test_read_at_end(self):
-        """Test reading when already at end of file"""
-        self.virtual_file.read()  # Read everything
-        self.assertEqual(self.virtual_file.read(), b"")
-
-    # Seek tests
-    def test_seek_set(self):
-        """Test seeking from start of file"""
-        self.virtual_file.seek(2, io.SEEK_SET)
-        self.assertEqual(self.virtual_file.read(), b"456")
-
-    def test_seek_cur(self):
-        """Test seeking from current position"""
-        self.virtual_file.read(2)  # Read "23"
-        self.virtual_file.seek(1, io.SEEK_CUR)
-        self.assertEqual(self.virtual_file.read(), b"56")
-
-    def test_seek_end(self):
-        """Test seeking from end of file"""
-        self.virtual_file.seek(-2, io.SEEK_END)
-        self.assertEqual(self.virtual_file.read(), b"56")
-
-    def test_seek_beyond_end(self):
-        """Test seeking beyond end of virtual file - should be allowed"""
-        self.virtual_file.seek(100, io.SEEK_SET)
-        self.assertEqual(self.virtual_file.tell(), 100)
-        self.assertEqual(self.virtual_file.read(), b"")
-
-    def test_seek_negative_set(self):
-        """Test seeking with negative offset using SEEK_SET - should raise ValueError"""
-        with self.assertRaises(ValueError):
-            self.virtual_file.seek(-1, io.SEEK_SET)
-
-    def test_seek_negative_cur(self):
-        """Test seeking with negative offset using SEEK_CUR - should clamp to start"""
-        self.virtual_file.read(3)  # Read "234"
-        self.virtual_file.seek(-2, io.SEEK_CUR)  # Go back 2 from position 3
-        self.assertEqual(self.virtual_file.read(2), b"34")
-
-        # Test clamping to start
-        self.virtual_file.read(3)  # Read "234"
-        self.virtual_file.seek(-10, io.SEEK_CUR)  # Try to go before start
-        self.assertEqual(self.virtual_file.tell(), 0)  # Should be clamped to start
-        self.assertEqual(self.virtual_file.read(), b"23456")  # Should read from start
-
-    def test_seek_negative_cur_clamping(self):
-        """Test that SEEK_CUR with negative offset clamps to start of file"""
-        self.virtual_file.read(2)  # Position is now 2
-        self.virtual_file.seek(-100, io.SEEK_CUR)  # Try to seek way before start
-        self.assertEqual(self.virtual_file.tell(), 0)  # Should be at start
-        self.assertEqual(self.virtual_file.read(), b"23456")  # Should read everything
-
-    def test_seek_negative_end(self):
-        """Test seeking with negative offset using SEEK_END - should be allowed"""
-        self.virtual_file.seek(-3, io.SEEK_END)
-        self.assertEqual(self.virtual_file.read(), b"456")
-
-    def test_read_after_seeking_beyond(self):
-        """Test reading after seeking beyond end of file"""
-        self.virtual_file.seek(10, io.SEEK_SET)
-        self.assertEqual(self.virtual_file.read(), b"")
-        self.assertEqual(self.virtual_file.read(1), b"")
-
-    # Tell tests
-    def test_tell_initial(self):
-        """Test initial position"""
-        self.assertEqual(self.virtual_file.tell(), 0)
-
-    def test_tell_after_read(self):
-        """Test position after reading"""
-        self.virtual_file.read(2)
-        self.assertEqual(self.virtual_file.tell(), 2)
-
-    def test_tell_after_seek(self):
-        """Test position after seeking"""
-        self.virtual_file.seek(3, io.SEEK_SET)
-        self.assertEqual(self.virtual_file.tell(), 3)
-
-    def test_tell_at_end(self):
-        """Test position at end of file"""
-        self.virtual_file.read()  # Read everything
-        self.assertEqual(self.virtual_file.tell(), 5)  # Virtual file is 5 bytes long
-
-    # Context manager tests
-    def test_context_manager(self):
-        """Test using VirtualFile as context manager"""
-        mock_file = io.BytesIO(b"0123456789")
-        with VirtualFile(mock_file, 2, 7) as vf:
-            self.assertEqual(vf.read(), b"23456")
-        self.assertTrue(mock_file.closed)
-
-    # Write tests
-    def test_writable(self):
-        """Test that VirtualFile is not writable"""
-        self.assertFalse(self.virtual_file.writable())
+@pytest.fixture
+def master_file() -> io.BytesIO:
+    f = io.BytesIO(b"0123456789")
+    yield f
+    f.close()
 
 
-if __name__ == "__main__":
-    unittest.main()
+@pytest.fixture
+def virtual_file(master_file: io.BytesIO) -> VirtualFile:
+    # virtual file from positions 2-7 (content should be "23456")
+    return VirtualFile(master_file, 2, 7)
+
+
+# Read tests
+def test_read_all(virtual_file: VirtualFile):
+    """Test reading entire virtual file"""
+    assert virtual_file.read() == b"23456"
+
+
+def test_read_partial(virtual_file: VirtualFile):
+    """Test reading specific number of bytes"""
+    assert virtual_file.read(2) == b"23"
+    assert virtual_file.read(2) == b"45"
+
+
+def test_read_beyond_bounds(virtual_file: VirtualFile):
+    """Test reading more bytes than available"""
+    assert virtual_file.read(1000) == b"23456"
+
+
+def test_read_at_end(virtual_file: VirtualFile):
+    """Test reading when already at end of file"""
+    virtual_file.read()  # Read everything
+    assert virtual_file.read() == b""
+
+
+# Seek tests
+def test_seek_set(virtual_file: VirtualFile):
+    """Test seeking from start of file"""
+    virtual_file.seek(2, io.SEEK_SET)
+    assert virtual_file.read() == b"456"
+
+
+def test_seek_cur(virtual_file: VirtualFile):
+    """Test seeking from current position"""
+    virtual_file.read(2)  # Read "23"
+    virtual_file.seek(1, io.SEEK_CUR)
+    assert virtual_file.read() == b"56"
+
+
+def test_seek_end(virtual_file: VirtualFile):
+    """Test seeking from end of file"""
+    virtual_file.seek(-2, io.SEEK_END)
+    assert virtual_file.read() == b"56"
+
+
+def test_seek_beyond_end(virtual_file: VirtualFile):
+    """Test seeking beyond end of virtual file - should be allowed"""
+    virtual_file.seek(100, io.SEEK_SET)
+    assert virtual_file.tell() == 100
+    assert virtual_file.read() == b""
+
+
+def test_seek_negative_set(virtual_file: VirtualFile):
+    """Test seeking with negative offset using SEEK_SET - should raise ValueError"""
+    with pytest.raises(ValueError):
+        virtual_file.seek(-1, io.SEEK_SET)
+
+
+def test_seek_negative_cur(virtual_file: VirtualFile):
+    """Test seeking with negative offset using SEEK_CUR - should clamp to start"""
+    virtual_file.read(3)  # Read "234"
+    virtual_file.seek(-2, io.SEEK_CUR)  # Go back 2 from position 3
+    assert virtual_file.read(2) == b"34"
+
+    # Test clamping to start
+    virtual_file.read(3)  # Read "234"
+    virtual_file.seek(-10, io.SEEK_CUR)  # Try to go before start
+    assert virtual_file.tell() == 0  # Should be clamped to start
+    assert virtual_file.read() == b"23456"  # Should read from start
+
+
+def test_seek_negative_cur_clamping(virtual_file: VirtualFile):
+    """Test that SEEK_CUR with negative offset clamps to start of file"""
+    virtual_file.read(2)  # Position is now 2
+    virtual_file.seek(-100, io.SEEK_CUR)  # Try to seek way before start
+    assert virtual_file.tell() == 0  # Should be at start
+    assert virtual_file.read() == b"23456"  # Should read everything
+
+
+def test_seek_negative_end(virtual_file: VirtualFile):
+    """Test seeking with negative offset using SEEK_END - should be allowed"""
+    virtual_file.seek(-3, io.SEEK_END)
+    assert virtual_file.read() == b"456"
+
+
+def test_read_after_seeking_beyond(virtual_file: VirtualFile):
+    """Test reading after seeking beyond end of file"""
+    virtual_file.seek(10, io.SEEK_SET)
+    assert virtual_file.read() == b""
+    assert virtual_file.read(1) == b""
+
+
+# Tell tests
+def test_tell_initial(virtual_file: VirtualFile):
+    """Test initial position"""
+    assert virtual_file.tell() == 0
+
+
+def test_tell_after_read(virtual_file: VirtualFile):
+    """Test position after reading"""
+    virtual_file.read(2)
+    assert virtual_file.tell() == 2
+
+
+def test_tell_after_seek(virtual_file: VirtualFile):
+    """Test position after seeking"""
+    virtual_file.seek(3, io.SEEK_SET)
+    assert virtual_file.tell() == 3
+
+
+def test_tell_at_end(virtual_file: VirtualFile):
+    """Test position at end of file"""
+    virtual_file.read()  # Read everything
+    assert virtual_file.tell() == 5  # Virtual file is 5 bytes long
+
+
+# Context manager tests
+def test_context_manager():
+    """Test using VirtualFile as context manager"""
+    mock_file = io.BytesIO(b"0123456789")
+    with VirtualFile(mock_file, 2, 7) as vf:
+        assert vf.read() == b"23456"
+    assert mock_file.closed
+
+
+# Write tests
+def test_writable(virtual_file: VirtualFile):
+    """Test that VirtualFile is not writable"""
+    assert not virtual_file.writable()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,14 +41,22 @@ beam = [
 test = [
     "pydicom==2.3.0",
     "matplotlib",
+    "pytest>=8.0.0",
 ]
 dev = [
     "pre-commit>=3.0.0",
     "pydicom==2.3.0",
     "matplotlib",
     "apache-beam[gcp]==2.63.0",
+    "pytest>=8.0.0",
 ]
 
 [tool.setuptools]
 packages = {find = {}}
 include-package-data = true
+
+[tool.pytest.ini_options]
+testpaths = ["cloud_optimized_dicom/tests"]
+python_files = ["test_*.py"]
+python_classes = ["Test*"]
+python_functions = ["test_*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ test = [
     "pydicom==2.3.0",
     "matplotlib",
     "pytest>=8.0.0",
+    "pytest-mock>=3.12.0",
 ]
 dev = [
     "pre-commit>=3.0.0",
@@ -49,6 +50,7 @@ dev = [
     "matplotlib",
     "apache-beam[gcp]==2.63.0",
     "pytest>=8.0.0",
+    "pytest-mock>=3.12.0",
 ]
 
 [tool.setuptools]


### PR DESCRIPTION
Replaces the `unittest.TestCase`-based test suite with idiomatic pytest, unlocking fixtures, parametrization, and richer assertion failures going forward. After this PR, no `unittest` imports remain in `cloud_optimized_dicom/tests/`.

- Add `pytest>=8.0.0` and `pytest-mock>=3.12.0` to test/dev deps and `[tool.pytest.ini_options]` config in `pyproject.toml`
- Introduce `cloud_optimized_dicom/tests/conftest.py` with shared session-scoped fixtures (`gcs_client`, `test_data_dir`, `local_instance_path`, UID constants) and a function-scoped `datastore_path` that wipes the bucket before each test
- Convert all 15 test files: drop `TestCase`/`setUpClass`/`setUp`, replace `self.assertX` with `assert`, `self.assertRaises` → `pytest.raises`, `@unittest.skipIf` → module-level `pytestmark = pytest.mark.skipif`, `assertLogs` → `caplog`, `assertAlmostEqual` → `pytest.approx`
- Replace `unittest.mock.patch` decorators in `test_custom_offset_tables.py` with the `mocker` fixture from `pytest-mock`
- Update CI (`.github/workflows/test.yml`) and `CLAUDE.md` to invoke `python -m pytest` instead of `python -m unittest discover`