### PR TITLE
ci(PROC-1570): use github app token for release-please

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,10 +24,21 @@ jobs:
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
     steps:
+      # GITHUB_TOKEN-authored events don't trigger workflow runs (cascade
+      # prevention), so the release PR's required checks would never run.
+      # Use an app token instead. See PROC-1570.
+      - id: app-token
+        if: github.event_name == 'push'
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.RELEASE_PLEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
+
       - id: release
         if: github.event_name == 'push'
         uses: googleapis/release-please-action@v4
         with:
+          token: ${{ steps.app-token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 


### PR DESCRIPTION
## Summary

- Mint a GitHub App installation token in `release.yml` and pass it to `googleapis/release-please-action@v4` instead of relying on the default `GITHUB_TOKEN`.
- Fixes the cascade-prevention issue where release PRs were `BLOCKED` because the `test` and `lint_and_format` checks (required by the Main ruleset) never auto-ran on `GITHUB_TOKEN`-authored events. Most recently bit us on #105.

## DO NOT MERGE until secrets exist

This change references two repo secrets that devops still needs to provision:

- `RELEASE_PLEASE_APP_ID`
- `RELEASE_PLEASE_APP_PRIVATE_KEY`

Both are populated from a new per-repo GitHub App with `Contents: Read & write` and `Pull requests: Read & write`. If this is merged before those secrets land, the next push to `main` will fail the `release-please` job at the token-minting step. Hold for devops handoff (tracked in PROC-1570).

## Test plan

- [ ] Confirm `RELEASE_PLEASE_APP_ID` and `RELEASE_PLEASE_APP_PRIVATE_KEY` exist as repo secrets.
- [ ] Mark PR ready for review and merge.
- [ ] On next push to `main`, verify the `release-please` job succeeds and the resulting release PR has all required checks running automatically (no manual close/reopen).