### PR TITLE
ci(PROC-1571): add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: monthly
+    groups:
+      python-dependencies:
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
Adds Dependabot to keep CI actions and Python dependencies current. Sized to keep PR noise low while still surfacing breaking changes for explicit review.

- `github-actions`: weekly, ungrouped (small surface; easy to review individually)
- `pip`: monthly, with `minor`/`patch` bumps grouped into one PR

Major bumps still arrive as individual PRs, so the `urllib3<2.6.0` cap and any other breaking updates get explicit review. The custom `pydicom3` is published to PyPI, so Dependabot resolves it like any other pinned dep.