### PR TITLE
ci(NO-ISSUE): use conventional commit prefix for dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,11 +4,17 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    commit-message:
+      prefix: chore
+      include: scope
 
   - package-ecosystem: pip
     directory: /
     schedule:
       interval: monthly
+    commit-message:
+      prefix: chore
+      include: scope
     groups:
       python-dependencies:
         update-types:


### PR DESCRIPTION
## Summary
- Configure `commit-message.prefix=chore` and `include=scope` in `.github/dependabot.yml` so dependabot generates titles like `chore(deps): bump X from Y to Z`.
- Without this, dependabot's default `Bump X from Y to Z` titles fail the `pr-title-conventional` check (no conventional type, capital `B` in subject).

## Test plan
- [ ] Existing open dependabot PRs have been retitled manually; verify their `conventional-prefix` check now passes.
- [ ] Next time dependabot opens a PR, confirm the title uses `chore(deps): ...` automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)