### PR TITLE
ci(NO-ISSUE): parallelize tests with pytest-xdist

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,7 @@ jobs:
     - name: Run tests
       env:
         SISKIN_ENV_ENABLED: 1
+        GITHUB_RUN_ID: ${{ github.run_id }}
       run: |
         set -o pipefail
         for attempt in 1 2 3; do
@@ -54,3 +55,23 @@ jobs:
         done
         echo "Tests failed after 3 attempts due to 429 errors."
         exit 1
+
+    # Sweep this run's GCS prefixes regardless of test outcome so failed
+    # runs don't leak orphan dirs forever.
+    - name: Clean up test namespace
+      if: always()
+      env:
+        GITHUB_RUN_ID: ${{ github.run_id }}
+      run: |
+        python - <<'PY'
+        import os
+        from google.cloud import storage
+        from cloud_optimized_dicom.utils import delete_uploaded_blobs
+        client = storage.Client(project="gradient-pacs-siskin-172863")
+        rid = os.environ["GITHUB_RUN_ID"]
+        delete_uploaded_blobs(client, [
+            f"gs://siskin-172863-temp/cod_tests/{rid}",
+            f"gs://siskin-172863-temp/cod_thumbnail_tests/{rid}",
+            f"gs://siskin-172863-temp/cod_error_log_tests/{rid}",
+        ])
+        PY

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,8 +35,6 @@ jobs:
 
     # Tests hit real GCS buckets and occasionally get transient 429 rate-limit errors.
     # Retry up to 3 times with a 30s backoff, but only when the failure is a 429.
-    # `--dist=loadfile` keeps tests from the same file on the same worker so
-    # files with module-level shared paths (e.g. test_concat.py) stay safe.
     - name: Run tests
       env:
         SISKIN_ENV_ENABLED: 1
@@ -44,7 +42,7 @@ jobs:
       run: |
         set -o pipefail
         for attempt in 1 2 3; do
-          python -m pytest -v -n auto --dist=loadfile cloud_optimized_dicom/tests 2>&1 | tee test_output.txt && exit 0
+          python -m pytest -v -n auto cloud_optimized_dicom/tests 2>&1 | tee test_output.txt && exit 0
           if grep -q "429" test_output.txt; then
             echo "Attempt $attempt failed with 429 rate-limit error, retrying in 30s..."
             sleep 30
@@ -73,5 +71,6 @@ jobs:
             f"gs://siskin-172863-temp/cod_tests/{rid}",
             f"gs://siskin-172863-temp/cod_thumbnail_tests/{rid}",
             f"gs://siskin-172863-temp/cod_error_log_tests/{rid}",
+            f"gs://siskin-172863-test-data/{rid}",
         ])
         PY

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,7 @@ jobs:
       with:
         python-version: 3.11
         cache: 'pip'
+        cache-dependency-path: 'pyproject.toml'
 
     - name: Install Python dependencies
       run: |
@@ -34,13 +35,15 @@ jobs:
 
     # Tests hit real GCS buckets and occasionally get transient 429 rate-limit errors.
     # Retry up to 3 times with a 30s backoff, but only when the failure is a 429.
+    # `--dist=loadfile` keeps tests from the same file on the same worker so
+    # files with module-level shared paths (e.g. test_concat.py) stay safe.
     - name: Run tests
       env:
         SISKIN_ENV_ENABLED: 1
       run: |
         set -o pipefail
         for attempt in 1 2 3; do
-          python -m pytest -v cloud_optimized_dicom/tests 2>&1 | tee test_output.txt && exit 0
+          python -m pytest -v -n auto --dist=loadfile cloud_optimized_dicom/tests 2>&1 | tee test_output.txt && exit 0
           if grep -q "429" test_output.txt; then
             echo "Attempt $attempt failed with 429 rate-limit error, retrying in 30s..."
             sleep 30

--- a/cloud_optimized_dicom/tests/conftest.py
+++ b/cloud_optimized_dicom/tests/conftest.py
@@ -32,11 +32,18 @@ def gcs_client() -> storage.Client:
     )
 
 
-@pytest.fixture()
-def datastore_path(gcs_client: storage.Client) -> str:
-    # Namespace by xdist worker so parallel workers don't clobber each other.
+@pytest.fixture(scope="session")
+def worker_namespace() -> str:
+    """Per-(run, worker) path segment so concurrent CI runs and parallel
+    xdist workers don't collide on the same GCS prefix."""
+    run_id = os.environ.get("GITHUB_RUN_ID", "local")
     worker = os.environ.get("PYTEST_XDIST_WORKER", "main")
-    path = f"{DATASTORE_BASE}/{worker}/dicomweb"
+    return f"{run_id}/{worker}"
+
+
+@pytest.fixture()
+def datastore_path(gcs_client: storage.Client, worker_namespace: str) -> str:
+    path = f"{DATASTORE_BASE}/{worker_namespace}/dicomweb"
     delete_uploaded_blobs(gcs_client, [path])
     return path
 

--- a/cloud_optimized_dicom/tests/conftest.py
+++ b/cloud_optimized_dicom/tests/conftest.py
@@ -7,7 +7,7 @@ from google.cloud import storage
 from cloud_optimized_dicom.utils import delete_uploaded_blobs
 
 GCP_PROJECT = "gradient-pacs-siskin-172863"
-DEFAULT_DATASTORE_PATH = "gs://siskin-172863-temp/cod_tests/dicomweb"
+DATASTORE_BASE = "gs://siskin-172863-temp/cod_tests"
 
 TEST_INSTANCE_UID = "1.2.276.0.50.192168001092.11156604.14547392.313"
 TEST_SERIES_UID = "1.2.276.0.50.192168001092.11156604.14547392.303"
@@ -34,8 +34,11 @@ def gcs_client() -> storage.Client:
 
 @pytest.fixture()
 def datastore_path(gcs_client: storage.Client) -> str:
-    delete_uploaded_blobs(gcs_client, [DEFAULT_DATASTORE_PATH])
-    return DEFAULT_DATASTORE_PATH
+    # Namespace by xdist worker so parallel workers don't clobber each other.
+    worker = os.environ.get("PYTEST_XDIST_WORKER", "main")
+    path = f"{DATASTORE_BASE}/{worker}/dicomweb"
+    delete_uploaded_blobs(gcs_client, [path])
+    return path
 
 
 @pytest.fixture(scope="session")

--- a/cloud_optimized_dicom/tests/test_concat.py
+++ b/cloud_optimized_dicom/tests/test_concat.py
@@ -2,6 +2,7 @@ import io
 import logging
 import os
 import tempfile
+from dataclasses import dataclass
 
 import pydicom3
 import pydicom3.tag
@@ -25,57 +26,24 @@ INSTANCE_UIDS = [
 ]
 BUCKET_NAME = "siskin-172863-test-data"
 GOLDEN_URI_PREFIX = "gs://siskin-172863-test-data/golden"
-PLAYGROUND_URI_PREFIX = "gs://siskin-172863-test-data/playground"
-OUTPUT_URI = "gs://siskin-172863-test-data/concat-output"
-FILE1 = {
-    "file_uri": f"{PLAYGROUND_URI_PREFIX}/{STUDY_UID}/series/{SERIES_UID}/instances/{INSTANCE_UIDS[0]}.dcm",
-    "size": 258118,
-    "crc32c": "1VFoRg==",
-    "instance_uid": INSTANCE_UIDS[0],
-}
-FILE1_NEW_VERSION = {
-    "file_uri": f"{PLAYGROUND_URI_PREFIX}/{STUDY_UID}/series/{SERIES_UID}/instances/{INSTANCE_UIDS[0]}_v2.dcm",
-    "size": 258118,
-    "crc32c": "1VFoRg==",
-    "instance_uid": INSTANCE_UIDS[0],
-}
-FILE2 = {
-    "file_uri": f"{PLAYGROUND_URI_PREFIX}/{STUDY_UID}/series/{SERIES_UID}/instances/{INSTANCE_UIDS[1]}.dcm",
-    "size": 270186,
-    "crc32c": "21UzbQ==",
-    "instance_uid": INSTANCE_UIDS[1],
-}
-FILE3 = {
-    "file_uri": f"{PLAYGROUND_URI_PREFIX}/{STUDY_UID}/series/{SERIES_UID}/instances/{INSTANCE_UIDS[2]}.dcm",
-    "size": 270058,
-    "crc32c": "t+Jnkw==",
-    "instance_uid": INSTANCE_UIDS[2],
-}
-GROUPING_FULL = {
-    "study_uid": STUDY_UID,
-    "series_uid": SERIES_UID,
-    "files": [FILE1, FILE2, FILE3],
-}
-GROUPING_SINGLE = {"study_uid": STUDY_UID, "series_uid": SERIES_UID, "files": [FILE1]}
-GROUPING_FIRST_TWO = {
-    "study_uid": STUDY_UID,
-    "series_uid": SERIES_UID,
-    "files": [FILE1, FILE2],
-}
-GROUPING_LAST_TWO = {
-    "study_uid": STUDY_UID,
-    "series_uid": SERIES_UID,
-    "files": [FILE2, FILE3],
-}
-GROUPING_INCLUDING_DUPE = {
-    "study_uid": STUDY_UID,
-    "series_uid": SERIES_UID,
-    "files": [FILE1, FILE1_NEW_VERSION],
-}
+
+FILE_SIZES = [258118, 270186, 270058]
+FILE_CRC32CS = ["1VFoRg==", "21UzbQ==", "t+Jnkw=="]
 
 pytestmark = pytest.mark.skipif(
     "SKIP_NETWORK_TESTS" in os.environ, reason="cloud storage"
 )
+
+
+@dataclass(frozen=True)
+class ConcatPaths:
+    output_uri: str
+    playground_prefix: str
+    grouping_full: dict
+    grouping_single: dict
+    grouping_first_two: dict
+    grouping_last_two: dict
+    grouping_including_dupe: dict
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -90,9 +58,41 @@ def test_bucket(gcs_client: storage.Client) -> storage.Bucket:
 
 
 @pytest.fixture
-def clean_concat_paths(gcs_client: storage.Client):
-    delete_uploaded_blobs(gcs_client, [OUTPUT_URI, PLAYGROUND_URI_PREFIX])
-    yield
+def concat_paths(gcs_client: storage.Client, worker_namespace: str) -> ConcatPaths:
+    """URIs and groupings for concat tests, namespaced per (run, worker).
+
+    Cleans the output and playground prefixes before yielding so each test
+    starts from a known-empty state.
+    """
+    playground = f"gs://{BUCKET_NAME}/{worker_namespace}/playground"
+    output = f"gs://{BUCKET_NAME}/{worker_namespace}/concat-output"
+    delete_uploaded_blobs(gcs_client, [output, playground])
+
+    def _file(idx: int, name_suffix: str = "") -> dict:
+        return {
+            "file_uri": (
+                f"{playground}/{STUDY_UID}/series/{SERIES_UID}/instances/"
+                f"{INSTANCE_UIDS[idx]}{name_suffix}.dcm"
+            ),
+            "size": FILE_SIZES[idx],
+            "crc32c": FILE_CRC32CS[idx],
+            "instance_uid": INSTANCE_UIDS[idx],
+        }
+
+    file1 = _file(0)
+    file1_v2 = _file(0, name_suffix="_v2")
+    file2 = _file(1)
+    file3 = _file(2)
+    base = {"study_uid": STUDY_UID, "series_uid": SERIES_UID}
+    return ConcatPaths(
+        output_uri=output,
+        playground_prefix=playground,
+        grouping_full={**base, "files": [file1, file2, file3]},
+        grouping_single={**base, "files": [file1]},
+        grouping_first_two={**base, "files": [file1, file2]},
+        grouping_last_two={**base, "files": [file2, file3]},
+        grouping_including_dupe={**base, "files": [file1, file1_v2]},
+    )
 
 
 def _copy_grouping_to_test_bucket(bucket: storage.Bucket, grouping: dict):
@@ -139,12 +139,13 @@ def run_group(
     gcs_client: storage.Client,
     bucket: storage.Bucket,
     grouping: dict,
+    output_uri: str,
     dryrun: bool = False,
 ) -> CODObject:
     """Upload a series, confirm it uploaded, confirm it deleted original"""
     _copy_grouping_to_test_bucket(bucket, grouping)
     codobj_instance_pairs = query_result_to_codobjects(
-        gcs_client, grouping, OUTPUT_URI, validate_datastore_path=False
+        gcs_client, grouping, output_uri, validate_datastore_path=False
     )
     assert len(codobj_instance_pairs) == 1
     cod_obj, instances = codobj_instance_pairs[0]
@@ -165,19 +166,27 @@ def run_group(
 
 
 def test_single_instance(
-    gcs_client: storage.Client, test_bucket: storage.Bucket, clean_concat_paths
+    gcs_client: storage.Client,
+    test_bucket: storage.Bucket,
+    concat_paths: ConcatPaths,
 ):
     """Upload single instance series, confirm it uploaded, confirm it deleted originals"""
     config.debug()
-    with run_group(gcs_client, test_bucket, GROUPING_SINGLE) as cod_obj:
+    with run_group(
+        gcs_client, test_bucket, concat_paths.grouping_single, concat_paths.output_uri
+    ) as cod_obj:
         pass
 
 
 def test_pipeline_and_check_offsets(
-    gcs_client: storage.Client, test_bucket: storage.Bucket, clean_concat_paths
+    gcs_client: storage.Client,
+    test_bucket: storage.Bucket,
+    concat_paths: ConcatPaths,
 ):
     """Upload a 3-instance series, confirm it uploaded, confirm you can read instance from tar using byte offsets"""
-    with run_group(gcs_client, test_bucket, GROUPING_FULL) as cod_obj:
+    with run_group(
+        gcs_client, test_bucket, concat_paths.grouping_full, concat_paths.output_uri
+    ) as cod_obj:
         with open(cod_obj.tar_file_path, "rb") as tar:
             for instance in cod_obj._metadata.instances.values():
                 assert instance._byte_offsets is not None
@@ -188,7 +197,9 @@ def test_pipeline_and_check_offsets(
 
 
 def test_dupe_instance(
-    gcs_client: storage.Client, test_bucket: storage.Bucket, clean_concat_paths
+    gcs_client: storage.Client,
+    test_bucket: storage.Bucket,
+    concat_paths: ConcatPaths,
 ):
     """
     Given instanceA, instanceB, and instanceC in a series,
@@ -196,7 +207,9 @@ def test_dupe_instance(
     are uploaded in 2 steps [instanceA, instanceB]; [instanceB, instanceC]
     """
     # get expected result of full upload
-    with run_group(gcs_client, test_bucket, GROUPING_FULL) as cod_obj:
+    with run_group(
+        gcs_client, test_bucket, concat_paths.grouping_full, concat_paths.output_uri
+    ) as cod_obj:
         # download normal bytes
         tar_blob = storage.Blob.from_string(cod_obj.tar_uri, client=gcs_client)
         tar_blob.download_as_bytes()
@@ -205,12 +218,24 @@ def test_dupe_instance(
         )
         metadata = SeriesMetadata.from_blob(metadata_blob)
     # wipe GCS
-    delete_uploaded_blobs(gcs_client, [OUTPUT_URI, PLAYGROUND_URI_PREFIX])
+    delete_uploaded_blobs(
+        gcs_client, [concat_paths.output_uri, concat_paths.playground_prefix]
+    )
     # copy & upload first partial series
-    with run_group(gcs_client, test_bucket, GROUPING_FIRST_TWO) as cod_obj_first_two:
+    with run_group(
+        gcs_client,
+        test_bucket,
+        concat_paths.grouping_first_two,
+        concat_paths.output_uri,
+    ) as cod_obj_first_two:
         pass
     # copy & upload second partial series
-    with run_group(gcs_client, test_bucket, GROUPING_LAST_TWO) as cod_obj_last_two:
+    with run_group(
+        gcs_client,
+        test_bucket,
+        concat_paths.grouping_last_two,
+        concat_paths.output_uri,
+    ) as cod_obj_last_two:
         # download duped bytes
         # duped_content = tar_blob.download_as_bytes()
         metadata_blob = storage.Blob.from_string(
@@ -225,17 +250,23 @@ def test_dupe_instance(
 def test_dupe_group(
     gcs_client: storage.Client,
     test_bucket: storage.Bucket,
-    clean_concat_paths,
+    concat_paths: ConcatPaths,
     caplog,
 ):
     """Upload the same group twice, confirm that instances were not fetched in second tar attempt"""
     # Run a standard upload
-    with run_group(gcs_client, test_bucket, GROUPING_FULL) as cod_obj_full:
+    with run_group(
+        gcs_client, test_bucket, concat_paths.grouping_full, concat_paths.output_uri
+    ) as cod_obj_full:
         pass
     # upload again, expecting 3 logs with "SKIP:DUPE_INSTANCE:SAME_HASH"
     with caplog.at_level(logging.INFO):
         with run_group(
-            gcs_client, test_bucket, GROUPING_FULL, dryrun=True
+            gcs_client,
+            test_bucket,
+            concat_paths.grouping_full,
+            concat_paths.output_uri,
+            dryrun=True,
         ) as cod_obj_full:
             pass
     print("\n".join(caplog.messages))
@@ -259,7 +290,7 @@ def test_dupe_group(
 def test_diff_hash(
     gcs_client: storage.Client,
     test_bucket: storage.Bucket,
-    clean_concat_paths,
+    concat_paths: ConcatPaths,
     test_data_dir: str,
 ):
     """
@@ -269,8 +300,8 @@ def test_diff_hash(
     """
     dcm_path = os.path.join(test_data_dir, "monochrome2.dcm")
     # upload a version of the dicom
-    v1_uri = f"{PLAYGROUND_URI_PREFIX}/version1.dcm"
-    v2_uri = f"{PLAYGROUND_URI_PREFIX}/version2.dcm"
+    v1_uri = f"{concat_paths.playground_prefix}/version1.dcm"
+    v2_uri = f"{concat_paths.playground_prefix}/version2.dcm"
     v1_blob = storage.Blob.from_string(v1_uri, client=gcs_client)
     v2_blob = storage.Blob.from_string(v2_uri, client=gcs_client)
     v1_blob.upload_from_filename(dcm_path)
@@ -290,7 +321,7 @@ def test_diff_hash(
     with CODObject(
         study_uid=study_uid,
         series_uid=series_uid,
-        datastore_path=OUTPUT_URI,
+        datastore_path=concat_paths.output_uri,
         client=gcs_client,
         mode="w",
     ) as cod_obj:
@@ -332,7 +363,7 @@ def test_diff_hash(
 def test_diff_hash_pixeldata(
     gcs_client: storage.Client,
     test_bucket: storage.Bucket,
-    clean_concat_paths,
+    concat_paths: ConcatPaths,
     test_data_dir: str,
 ):
     """
@@ -342,8 +373,8 @@ def test_diff_hash_pixeldata(
     """
     dcm_path = os.path.join(test_data_dir, "monochrome1.dcm")
     # upload a version of the dicom
-    v1_uri = f"{PLAYGROUND_URI_PREFIX}/version1.dcm"
-    v2_uri = f"{PLAYGROUND_URI_PREFIX}/version2.dcm"
+    v1_uri = f"{concat_paths.playground_prefix}/version1.dcm"
+    v2_uri = f"{concat_paths.playground_prefix}/version2.dcm"
     v1_blob = storage.Blob.from_string(v1_uri, client=gcs_client)
     v2_blob = storage.Blob.from_string(v2_uri, client=gcs_client)
     v1_blob.upload_from_filename(dcm_path, retry=DEFAULT_RETRY)
@@ -364,7 +395,7 @@ def test_diff_hash_pixeldata(
     assert v1_blob.crc32c != v2_blob.crc32c
 
     with CODObject(
-        datastore_path=OUTPUT_URI,
+        datastore_path=concat_paths.output_uri,
         client=gcs_client,
         study_uid=study_uid,
         series_uid=series_uid,
@@ -396,7 +427,9 @@ def test_diff_hash_pixeldata(
 
 
 def test_repeat_in_input(
-    gcs_client: storage.Client, test_bucket: storage.Bucket, clean_concat_paths
+    gcs_client: storage.Client,
+    test_bucket: storage.Bucket,
+    concat_paths: ConcatPaths,
 ):
     """
     Test behavior when the same instance is supplied multiple times.
@@ -405,11 +438,11 @@ def test_repeat_in_input(
      - duplicates & singles: [instanceA, instanceB, instanceB]
      - only duplicates: [instanceA, instanceA]
     """
-    _copy_grouping_to_test_bucket(test_bucket, GROUPING_INCLUDING_DUPE)
+    _copy_grouping_to_test_bucket(test_bucket, concat_paths.grouping_including_dupe)
     codobj_instance_pairs = query_result_to_codobjects(
         gcs_client,
-        GROUPING_INCLUDING_DUPE,
-        OUTPUT_URI,
+        concat_paths.grouping_including_dupe,
+        concat_paths.output_uri,
         validate_datastore_path=False,
     )
     cod_obj, instances = codobj_instance_pairs[0]
@@ -422,13 +455,18 @@ def test_repeat_in_input(
 
 
 def test_error_overlarge_instances(
-    gcs_client: storage.Client, test_bucket: storage.Bucket, clean_concat_paths
+    gcs_client: storage.Client,
+    test_bucket: storage.Bucket,
+    concat_paths: ConcatPaths,
 ):
     """Expect instances to be skipped if they are too large"""
     # set max size to 100 bytes; pipeline should raise ValueError
-    _copy_grouping_to_test_bucket(test_bucket, GROUPING_FULL)
+    _copy_grouping_to_test_bucket(test_bucket, concat_paths.grouping_full)
     codobj_instance_pairs = query_result_to_codobjects(
-        gcs_client, GROUPING_FULL, OUTPUT_URI, validate_datastore_path=False
+        gcs_client,
+        concat_paths.grouping_full,
+        concat_paths.output_uri,
+        validate_datastore_path=False,
     )
     cod_obj, instances = codobj_instance_pairs[0]
     max_instance_size = 10000 / 1073741824
@@ -442,11 +480,16 @@ def test_error_overlarge_instances(
 
 
 def test_error_overlarge_series(
-    gcs_client: storage.Client, test_bucket: storage.Bucket, clean_concat_paths
+    gcs_client: storage.Client,
+    test_bucket: storage.Bucket,
+    concat_paths: ConcatPaths,
 ):
     """Expect a ValueError if series is too large"""
     codobj_instance_pairs = query_result_to_codobjects(
-        gcs_client, GROUPING_FULL, OUTPUT_URI, validate_datastore_path=False
+        gcs_client,
+        concat_paths.grouping_full,
+        concat_paths.output_uri,
+        validate_datastore_path=False,
     )
     cod_obj, instances = codobj_instance_pairs[0]
     max_series_size = 10000 / 1073741824

--- a/cloud_optimized_dicom/tests/test_error_log.py
+++ b/cloud_optimized_dicom/tests/test_error_log.py
@@ -18,9 +18,8 @@ pytestmark = pytest.mark.skipif(
 
 
 @pytest.fixture
-def error_log_datastore_path(gcs_client: storage.Client) -> str:
-    worker = os.environ.get("PYTEST_XDIST_WORKER", "main")
-    path = f"{ERROR_LOG_DATASTORE_BASE}/{worker}/dicomweb"
+def error_log_datastore_path(gcs_client: storage.Client, worker_namespace: str) -> str:
+    path = f"{ERROR_LOG_DATASTORE_BASE}/{worker_namespace}/dicomweb"
     delete_uploaded_blobs(gcs_client, [path])
     return path
 

--- a/cloud_optimized_dicom/tests/test_error_log.py
+++ b/cloud_optimized_dicom/tests/test_error_log.py
@@ -8,7 +8,7 @@ from cloud_optimized_dicom.cod_object import CODObject
 from cloud_optimized_dicom.errors import ErrorLogExistsError
 from cloud_optimized_dicom.utils import delete_uploaded_blobs
 
-ERROR_LOG_DATASTORE_PATH = "gs://siskin-172863-temp/cod_error_log_tests/dicomweb"
+ERROR_LOG_DATASTORE_BASE = "gs://siskin-172863-temp/cod_error_log_tests"
 ERROR_LOG_STUDY_UID = "1.2.3.4.5.6.7.8.9.10"
 ERROR_LOG_SERIES_UID = "1.2.3.4.5.6.7.8.9.10"
 
@@ -19,8 +19,10 @@ pytestmark = pytest.mark.skipif(
 
 @pytest.fixture
 def error_log_datastore_path(gcs_client: storage.Client) -> str:
-    delete_uploaded_blobs(gcs_client, [ERROR_LOG_DATASTORE_PATH])
-    return ERROR_LOG_DATASTORE_PATH
+    worker = os.environ.get("PYTEST_XDIST_WORKER", "main")
+    path = f"{ERROR_LOG_DATASTORE_BASE}/{worker}/dicomweb"
+    delete_uploaded_blobs(gcs_client, [path])
+    return path
 
 
 def test_error_log_upload(gcs_client: storage.Client, error_log_datastore_path: str):

--- a/cloud_optimized_dicom/tests/test_thumbnail.py
+++ b/cloud_optimized_dicom/tests/test_thumbnail.py
@@ -21,7 +21,7 @@ from cloud_optimized_dicom.thumbnail import (
 )
 from cloud_optimized_dicom.utils import delete_uploaded_blobs
 
-THUMBNAIL_DATASTORE_PATH = "gs://siskin-172863-temp/cod_thumbnail_tests/dicomweb"
+THUMBNAIL_DATASTORE_BASE = "gs://siskin-172863-temp/cod_thumbnail_tests"
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -32,8 +32,10 @@ def _enable_logging():
 
 @pytest.fixture
 def thumbnail_datastore_path(gcs_client: storage.Client) -> str:
-    delete_uploaded_blobs(gcs_client, [THUMBNAIL_DATASTORE_PATH])
-    return THUMBNAIL_DATASTORE_PATH
+    worker = os.environ.get("PYTEST_XDIST_WORKER", "main")
+    path = f"{THUMBNAIL_DATASTORE_BASE}/{worker}/dicomweb"
+    delete_uploaded_blobs(gcs_client, [path])
+    return path
 
 
 def ingest_and_generate_thumbnail(

--- a/cloud_optimized_dicom/tests/test_thumbnail.py
+++ b/cloud_optimized_dicom/tests/test_thumbnail.py
@@ -31,9 +31,8 @@ def _enable_logging():
 
 
 @pytest.fixture
-def thumbnail_datastore_path(gcs_client: storage.Client) -> str:
-    worker = os.environ.get("PYTEST_XDIST_WORKER", "main")
-    path = f"{THUMBNAIL_DATASTORE_BASE}/{worker}/dicomweb"
+def thumbnail_datastore_path(gcs_client: storage.Client, worker_namespace: str) -> str:
+    path = f"{THUMBNAIL_DATASTORE_BASE}/{worker_namespace}/dicomweb"
     delete_uploaded_blobs(gcs_client, [path])
     return path
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ test = [
     "matplotlib",
     "pytest>=8.0.0",
     "pytest-mock>=3.12.0",
+    "pytest-xdist>=3.6.0",
 ]
 dev = [
     "pre-commit>=3.0.0",
@@ -51,6 +52,7 @@ dev = [
     "apache-beam[gcp]==2.63.0",
     "pytest>=8.0.0",
     "pytest-mock>=3.12.0",
+    "pytest-xdist>=3.6.0",
 ]
 
 [tool.setuptools]


### PR DESCRIPTION
## Summary

Parallelize the test suite with `pytest-xdist` and isolate writable GCS prefixes per (CI run, xdist worker) so neither concurrent CI runs nor parallel workers collide. CI test job drops from ~2m44s to ~1m17s; pytest itself drops from ~104s to ~28s.

## What changed

- Add `pytest-xdist>=3.6.0` to `test` and `dev` extras; run pytest with `-n auto` in CI (no `--dist=loadfile` needed once concat is namespaced — see below).
- Add a session-scoped `worker_namespace` fixture in `conftest.py` returning `{GITHUB_RUN_ID}/{PYTEST_XDIST_WORKER}` (defaults `local/main` outside CI). Four datastore fixtures consume it:
  - `datastore_path` (conftest.py)
  - `thumbnail_datastore_path` (test_thumbnail.py)
  - `error_log_datastore_path` (test_error_log.py)
  - `concat_paths` (test_concat.py) — new dataclass fixture replacing module-level `OUTPUT_URI`, `PLAYGROUND_URI_PREFIX`, `FILE*`, and `GROUPING_*` constants; `run_group` now takes `output_uri` as a parameter.
- `test_dicomweb.py` and `GOLDEN_URI_PREFIX` are read-only, so no namespacing needed.
- Pass `GITHUB_RUN_ID` into the test step and add an `if: always()` cleanup step that wipes the run's prefix from all four temp dirs (`cod_tests`, `cod_thumbnail_tests`, `cod_error_log_tests`, `siskin-172863-test-data/{run_id}`) so failed and successful runs alike don't leak orphan dirs.
- Pin `cache-dependency-path: 'pyproject.toml'` on `actions/setup-python` so the pip cache key stays stable.

## Why fold `GITHUB_RUN_ID` into the namespace

Worker ids (`gw0`, `gw1`, …) are stable across concurrent CI runs, so two runs colliding on the same `cod_tests/gw0/...` prefix would clobber each other's `delete_uploaded_blobs()` cleanup. This was originally called out as a pre-existing race but turned out to actually bite dependabot PRs running alongside other CI. `{run_id}/{worker}` makes each run's namespace unique; the `if: always()` cleanup step keeps the bucket from accumulating orphan dirs.

## Why refactor `test_concat.py`

It had module-level `OUTPUT_URI`, `PLAYGROUND_URI_PREFIX`, and `FILE*` / `GROUPING_*` dicts in a different bucket (`siskin-172863-test-data`) that were also shared across concurrent runs. Without the refactor we'd need `--dist=loadfile` to keep all concat tests on a single worker, capping intra-file parallelism. Folding them into a per-(run, worker) `ConcatPaths` dataclass fixture lets us drop `loadfile` and let xdist distribute individual tests freely.

## Timing

| | pytest | total CI job |
| --- | --- | --- |
| baseline (serial, recent main) | ~104s | ~2m44s |
| this PR | **~28s** | **~1m17s** |

## Known followups (out of scope)

- `test_locking.py::test_override_stale_lock` is occasionally flaky on real GCS regardless of parallelism. The workflow's 429-retry already handles transient failures.

## Test plan

- [x] CI test job passes on this PR (run 25122495097, 28.07s pytest / 1m17s job)
- [x] Pytest runtime visibly shorter than recent main runs (~104s → ~28s)
- [x] Cleanup step succeeds on green run
- [ ] Cleanup step succeeds on a deliberately-failed run (covered by `if: always()`, not exercised here)
- [ ] No new flakes attributable to namespacing