### PR TITLE
ci(NO-ISSUE): ignore pydicom in dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,10 @@ updates:
     commit-message:
       prefix: chore
       include: scope
+    ignore:
+      # pydicom is pinned at 2.3.0 to validate output from the pydicom3 fork;
+      # bumping it would silently break that validation.
+      - dependency-name: pydicom
     groups:
       python-dependencies:
         update-types:


### PR DESCRIPTION
## Summary
- Add `ignore: dependency-name: pydicom` so dependabot stops proposing pydicom bumps every month.
- The repo pins `pydicom==2.3.0` in the `test` extras intentionally — it's used to validate output from the `pydicom3` fork. Bumping it would silently break that validation.
- Closes the two open dependabot pydicom PRs (#104 → 2.4.5, #114 → 3.0.2).

## Test plan
- [ ] Confirm `dependabot.yml` parses (validated by dependabot on next schedule).
- [ ] No new pydicom PRs appear after the next monthly run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)