### PR TITLE
fix(PROC-940): unpin urllib3 now that google-resumable-media ships the fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,6 @@ dependencies = [
     "zstandard>=0.24.0",
     # Floor ensures the urllib3 2.6+ Gzip/Brotli decoder fix from upstream PR #495 is installed.
     "google-resumable-media>=2.8.1",
-    "urllib3>=2.0.0",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,8 +30,9 @@ dependencies = [
     "opencv-python-headless==4.11.0.86",
     "ffmpeg-python==0.2.0",
     "zstandard>=0.24.0",
-    # Pin urllib3 to avoid bug in 2.6.x where _GzipDecoder.decompress() doesn't accept max_length parameter
-    "urllib3>=2.0.0,<2.6.0",
+    # Floor ensures the urllib3 2.6+ Gzip/Brotli decoder fix from upstream PR #495 is installed.
+    "google-resumable-media>=2.8.1",
+    "urllib3>=2.0.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- `google-resumable-media 2.8.1` (released 2026-03-12) contains the urllib3 2.6+ fix from upstream PR #495 (`max_length` support in Gzip/Brotli decoders).
- Pin a floor on `google-resumable-media>=2.8.1` to ensure the fixed version is installed transitively (`google-cloud-storage 3.10.1` only requires `>=2.7.2`, which would otherwise allow a pre-fix version to resolve).
- Drop the `urllib3<2.6.0` cap.

Closes #98.

Linear: [PROC-940](https://linear.app/gradienthealth/issue/PROC-940/unpin-urllib3-version-once-google-resumable-media-releases-fix)

## Test plan
- [ ] CI tests pass.
- [ ] `pip install -e .` resolves to `urllib3>=2.6.0` and `google-resumable-media>=2.8.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)