### PR TITLE
fix(NO-ISSUE): migrate to ratarmountcore 0.10 mountsource API

### DIFF
--- a/cloud_optimized_dicom/append.py
+++ b/cloud_optimized_dicom/append.py
@@ -2,7 +2,7 @@ import os
 import tarfile
 from typing import TYPE_CHECKING, Iterable, NamedTuple, Optional
 
-from ratarmountcore import open as rmc_open
+from ratarmountcore.mountsource.factory import open_mount_source as rmc_open
 
 import cloud_optimized_dicom.metrics as metrics
 from cloud_optimized_dicom.config import logger

--- a/cloud_optimized_dicom/cod_object.py
+++ b/cloud_optimized_dicom/cod_object.py
@@ -10,7 +10,7 @@ from google.api_core.exceptions import NotFound
 from google.cloud import storage
 from google.cloud.storage.constants import STANDARD_STORAGE_CLASS
 from google.cloud.storage.retry import DEFAULT_RETRY
-from ratarmountcore import open as rmc_open
+from ratarmountcore.mountsource.factory import open_mount_source as rmc_open
 
 import cloud_optimized_dicom.metrics as metrics
 from cloud_optimized_dicom.append import append
@@ -656,11 +656,13 @@ class CODObject:
         # fetch the tar and index
         self._force_fetch_tar(fetch_index=True)
         # Attempt to open the tar using the index file. If they do not match, this will raise an error and we will know there's a desync
-        with rmc_open(self.tar_file_path, indexFile=self.index_file_path) as archive:
+        with rmc_open(
+            self.tar_file_path, indexFilePath=self.index_file_path
+        ) as archive:
             # generate a dict of instance_uid -> crc32c for each instance in the tar
             tar_instances = {}
-            for instance in archive.listDir("instances"):
-                file_info = archive.getFileInfo(f"instances/{instance}")
+            for instance in archive.list("instances"):
+                file_info = archive.lookup(f"instances/{instance}")
                 with archive.open(file_info) as f:
                     tar_instances[os.path.splitext(instance)[0]] = generate_ptr_crc32c(
                         f

--- a/cloud_optimized_dicom/instance.py
+++ b/cloud_optimized_dicom/instance.py
@@ -8,7 +8,7 @@ from typing import Callable, Optional
 import pydicom3
 import pydicom3.uid
 from pydicom3.datadict import tag_for_keyword
-from ratarmountcore import open as rmc_open
+from ratarmountcore.mountsource.factory import open_mount_source as rmc_open
 from smart_open import open as smart_open
 
 import cloud_optimized_dicom.metrics as metrics
@@ -297,7 +297,7 @@ class Instance:
             if os.path.exists(f"{tar_path}.index.sqlite"):
                 options = {"indexFilePath": f"{tar_path}.index.sqlite"}
             with rmc_open(f"{tar_path}.tar", **options) as archive:
-                internal_file_info = archive.getFileInfo(internal_path)
+                internal_file_info = archive.lookup(internal_path)
                 if not internal_file_info:
                     raise FileNotFoundError(f"File not found in tar: {internal_path}")
                 # set size if necessary

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 ]
 dependencies = [
     "smart-open==7.0.4",
-    "ratarmountcore==0.7.1",
+    "ratarmountcore==0.10.4",
     "numpy",
     "google-cloud-storage==3.10.1",
     "filetype==1.2.0",


### PR DESCRIPTION
## Summary
ratarmountcore 0.10.0 (released 2025-08-16) reorganized the public API. Migrate the three call sites and bump the pin from 0.7.1 → 0.10.4 so we can take subsequent updates.

### API changes applied
| Old (0.7.x) | New (0.10.x) |
| --- | --- |
| `from ratarmountcore import open` | `from ratarmountcore.mountsource.factory import open_mount_source` |
| `archive.listDir(path)` | `archive.list(path)` |
| `archive.getFileInfo(path)` | `archive.lookup(path)` |
| `indexFile=` kwarg | `indexFilePath=` kwarg |

`FileInfo.size` and `userdata[].offset` are unchanged. `archive.open(file_info)` is unchanged.

### Files touched
- `cloud_optimized_dicom/append.py` — import only
- `cloud_optimized_dicom/cod_object.py` — import + `indexFile`→`indexFilePath` + `listDir`→`list` + `getFileInfo`→`lookup`
- `cloud_optimized_dicom/instance.py` — import + `getFileInfo`→`lookup`
- `pyproject.toml` — bump `ratarmountcore==0.7.1` → `==0.10.4`

### Effect on dependabot grouped PR #113
That PR tries to bump ratarmountcore as part of a 7-package group. With this PR merged, ratarmountcore is already at 0.10.4 on main. Close #113 once this lands; dependabot's next monthly run will produce a smaller group with the remaining 6 routine bumps.

## Test plan
- [ ] CI green (pytest exercises the new API via `test_cod_object.py`, `test_instance.py`, `test_append*.py`).
- [ ] No `ImportError` from the test collection phase.