### PR TITLE
feat(PROC-1576): redact pixel data via bounding boxes in edit mode

### DIFF
--- a/cloud_optimized_dicom/cod_object.py
+++ b/cloud_optimized_dicom/cod_object.py
@@ -28,7 +28,7 @@ from cloud_optimized_dicom.errors import (
 )
 from cloud_optimized_dicom.instance import Instance
 from cloud_optimized_dicom.locker import CODLocker
-from cloud_optimized_dicom.redact import FillValue, apply_redactions
+from cloud_optimized_dicom.redact import FillValue, redact_pixel_data
 from cloud_optimized_dicom.series_metadata import SeriesMetadata
 from cloud_optimized_dicom.thumbnail import (
     DEFAULT_SIZE,
@@ -456,8 +456,9 @@ class CODObject:
         Must be called inside a `mode='e'` context. Each `BoundingBox` is
         applied to its `applies_to` instance UIDs (and the listed `frames`,
         or all frames if `frames is None`); affected instances are
-        re-encoded with their original transfer syntax. An audit record is
-        appended to series-level `metadata_fields["redactions"]`.
+        re-encoded as JPEG 2000 Lossless regardless of source transfer
+        syntax. An audit record is appended to series-level
+        `metadata_fields["redactions"]`.
 
         Hard-fails before any disk write if any of the following hold:
 
@@ -465,7 +466,6 @@ class CODObject:
         * A `BoundingBox.frames` index is out of range for its instance.
         * A `BoundingBox` is not fully contained in the target frame's
           `(Rows, Columns)`.
-        * The original transfer syntax has no usable encoder installed.
         * `fill_value` is incompatible with the target's
           `PhotometricInterpretation` / `SamplesPerPixel`.
 
@@ -474,10 +474,12 @@ class CODObject:
             reviewer: Identifier of the human reviewer who requested the
                 redaction; recorded verbatim in the audit trail.
             fill_value: Pixel value used to fill each box. If None, defaults
-                to whatever displays as black for the dataset's
-                PhotometricInterpretation (e.g. 0 for MONOCHROME2).
+                to whatever displays as black for the (post-decode)
+                PhotometricInterpretation: 0 for MONOCHROME2,
+                2**BitsStored - 1 for MONOCHROME1, (0, 0, 0) for any
+                color photometric interpretation.
         """
-        apply_redactions(self, boxes, reviewer=reviewer, fill_value=fill_value)
+        redact_pixel_data(self, boxes, reviewer=reviewer, fill_value=fill_value)
 
     def _sync(self, tar_storage_class: str = STANDARD_STORAGE_CLASS):
         """Private: Sync tar+index and/or metadata to GCS, as needed.

--- a/cloud_optimized_dicom/cod_object.py
+++ b/cloud_optimized_dicom/cod_object.py
@@ -14,7 +14,7 @@ from ratarmountcore.mountsource.factory import open_mount_source as rmc_open
 
 import cloud_optimized_dicom.metrics as metrics
 from cloud_optimized_dicom.append import append
-from cloud_optimized_dicom.bounding_box import BoundingBox
+from cloud_optimized_dicom.bounding_box import PixelRedaction
 from cloud_optimized_dicom.config import logger
 from cloud_optimized_dicom.edit import EditState, _validate_and_repack_for_edit
 from cloud_optimized_dicom.errors import (
@@ -446,14 +446,14 @@ class CODObject:
     @public_method(write_only=True)
     def redact_pixel_data(
         self,
-        boxes: list[BoundingBox],
+        redactions: list[PixelRedaction],
         *,
         reviewer: str,
         fill_value: Optional[FillValue] = None,
     ) -> None:
         """Black out pixel-data regions on instances in this series.
 
-        Must be called inside a `mode='e'` context. Each `BoundingBox` is
+        Must be called inside a `mode='e'` context. Each `PixelRedaction` is
         applied to its `applies_to` instance UIDs (and the listed `frames`,
         or all frames if `frames is None`); affected instances are
         re-encoded as JPEG 2000 Lossless regardless of source transfer
@@ -462,15 +462,15 @@ class CODObject:
 
         Hard-fails before any disk write if any of the following hold:
 
-        * A `BoundingBox.applies_to` UID is not present in this series.
-        * A `BoundingBox.frames` index is out of range for its instance.
-        * A `BoundingBox` is not fully contained in the target frame's
-          `(Rows, Columns)`.
+        * A `PixelRedaction.applies_to` UID is not present in this series.
+        * A `PixelRedaction.frames` index is out of range for its instance.
+        * A `PixelRedaction.box` is not fully contained in the target
+          frame's `(Rows, Columns)`.
         * `fill_value` is incompatible with the target's
           `PhotometricInterpretation` / `SamplesPerPixel`.
 
         Args:
-            boxes: Bounding boxes to apply.
+            redactions: Redactions to apply.
             reviewer: Identifier of the human reviewer who requested the
                 redaction; recorded verbatim in the audit trail.
             fill_value: Pixel value used to fill each box. If None, defaults
@@ -479,7 +479,7 @@ class CODObject:
                 2**BitsStored - 1 for MONOCHROME1, (0, 0, 0) for any
                 color photometric interpretation.
         """
-        redact_pixel_data(self, boxes, reviewer=reviewer, fill_value=fill_value)
+        redact_pixel_data(self, redactions, reviewer=reviewer, fill_value=fill_value)
 
     def _sync(self, tar_storage_class: str = STANDARD_STORAGE_CLASS):
         """Private: Sync tar+index and/or metadata to GCS, as needed.

--- a/cloud_optimized_dicom/cod_object.py
+++ b/cloud_optimized_dicom/cod_object.py
@@ -14,6 +14,7 @@ from ratarmountcore.mountsource.factory import open_mount_source as rmc_open
 
 import cloud_optimized_dicom.metrics as metrics
 from cloud_optimized_dicom.append import append
+from cloud_optimized_dicom.bounding_box import BoundingBox
 from cloud_optimized_dicom.config import logger
 from cloud_optimized_dicom.edit import EditState, _validate_and_repack_for_edit
 from cloud_optimized_dicom.errors import (
@@ -27,6 +28,7 @@ from cloud_optimized_dicom.errors import (
 )
 from cloud_optimized_dicom.instance import Instance
 from cloud_optimized_dicom.locker import CODLocker
+from cloud_optimized_dicom.redact import FillValue, apply_redactions
 from cloud_optimized_dicom.series_metadata import SeriesMetadata
 from cloud_optimized_dicom.thumbnail import (
     DEFAULT_SIZE,
@@ -440,6 +442,42 @@ class CODObject:
             max_series_size=max_series_size,
             compress=compress,
         )
+
+    @public_method(write_only=True)
+    def redact_pixel_data(
+        self,
+        boxes: list[BoundingBox],
+        *,
+        reviewer: str,
+        fill_value: Optional[FillValue] = None,
+    ) -> None:
+        """Black out pixel-data regions on instances in this series.
+
+        Must be called inside a `mode='e'` context. Each `BoundingBox` is
+        applied to its `applies_to` instance UIDs (and the listed `frames`,
+        or all frames if `frames is None`); affected instances are
+        re-encoded with their original transfer syntax. An audit record is
+        appended to series-level `metadata_fields["redactions"]`.
+
+        Hard-fails before any disk write if any of the following hold:
+
+        * A `BoundingBox.applies_to` UID is not present in this series.
+        * A `BoundingBox.frames` index is out of range for its instance.
+        * A `BoundingBox` is not fully contained in the target frame's
+          `(Rows, Columns)`.
+        * The original transfer syntax has no usable encoder installed.
+        * `fill_value` is incompatible with the target's
+          `PhotometricInterpretation` / `SamplesPerPixel`.
+
+        Args:
+            boxes: Bounding boxes to apply.
+            reviewer: Identifier of the human reviewer who requested the
+                redaction; recorded verbatim in the audit trail.
+            fill_value: Pixel value used to fill each box. If None, defaults
+                to whatever displays as black for the dataset's
+                PhotometricInterpretation (e.g. 0 for MONOCHROME2).
+        """
+        apply_redactions(self, boxes, reviewer=reviewer, fill_value=fill_value)
 
     def _sync(self, tar_storage_class: str = STANDARD_STORAGE_CLASS):
         """Private: Sync tar+index and/or metadata to GCS, as needed.

--- a/cloud_optimized_dicom/errors.py
+++ b/cloud_optimized_dicom/errors.py
@@ -58,3 +58,24 @@ class InstanceValidationError(CODError):
 class EditSetChangedError(CODError):
     """Exception raised on exit from mode='e' when the instance set changed during
     the edit (a DICOM file was deleted/moved/renamed, or its UIDs were mutated)."""
+
+
+class RedactionError(CODError):
+    """Base class for pixel-data redaction failures (see redact.py)."""
+
+
+class RedactionTargetMissingError(RedactionError):
+    """A bbox.applies_to UID does not exist in the target series."""
+
+
+class RedactionFrameOutOfRangeError(RedactionError):
+    """A bbox.frames index is out of range for its target instance."""
+
+
+class RedactionBoxOutOfBoundsError(RedactionError):
+    """A bbox is not fully contained in (Rows, Columns) of its target frame."""
+
+
+class RedactionFillValueError(RedactionError):
+    """The provided fill_value is incompatible with the target's PhotometricInterpretation
+    or SamplesPerPixel."""

--- a/cloud_optimized_dicom/redact.py
+++ b/cloud_optimized_dicom/redact.py
@@ -1,6 +1,6 @@
 """Pixel-data redaction via mode='e'.
 
-Reviewer-supplied bounding boxes are blacked out in each target instance's
+Reviewer-supplied redactions are blacked out in each target instance's
 PixelData, then the instance is re-encoded as JPEG 2000 Lossless. An audit
 record is appended to series-level metadata_fields["redactions"] so the
 action is traceable later.
@@ -13,6 +13,7 @@ hard dependency, and (c) matches what append.py already does on ingest, so
 in practice nothing's changing format for already-stored data.
 """
 
+import dataclasses
 import datetime
 from collections import defaultdict
 from typing import TYPE_CHECKING, Optional, Union
@@ -21,7 +22,7 @@ import numpy as np
 import pydicom3
 from pydicom3.uid import JPEG2000Lossless
 
-from cloud_optimized_dicom.bounding_box import BoundingBox
+from cloud_optimized_dicom.bounding_box import PixelRedaction
 from cloud_optimized_dicom.errors import (
     RedactionBoxOutOfBoundsError,
     RedactionFillValueError,
@@ -53,7 +54,7 @@ FillValue = Union[int, tuple[int, ...]]
 
 def redact_pixel_data(
     cod_object: "CODObject",
-    boxes: list[BoundingBox],
+    redactions: list[PixelRedaction],
     *,
     reviewer: str,
     fill_value: Optional[FillValue] = None,
@@ -66,47 +67,47 @@ def redact_pixel_data(
         )
 
     instances = cod_object._get_instances(strict_sorting=False)
-    boxes_by_uid = _group_boxes_by_uid(boxes, instances)
+    redactions_by_uid = _group_by_uid(redactions, instances)
 
     # Pre-flight: read each affected instance's header (no pixel decode) and
-    # validate every box against it. Raises before any pixel data is decoded
-    # or written.
-    for uid, uid_boxes in boxes_by_uid.items():
+    # validate every redaction against it. Raises before any pixel data is
+    # decoded or written.
+    for uid, uid_redactions in redactions_by_uid.items():
         ds = pydicom3.dcmread(instances[uid].dicom_uri, stop_before_pixels=True)
-        _validate_box_set_against_header(uid, ds, uid_boxes, fill_value)
+        _validate_redactions_against_header(uid, ds, uid_redactions, fill_value)
 
     # Apply pass.
     now = datetime.datetime.now(datetime.timezone.utc)
-    for uid, uid_boxes in boxes_by_uid.items():
+    for uid, uid_redactions in redactions_by_uid.items():
         _apply_to_instance(
             instance=instances[uid],
-            boxes=uid_boxes,
+            redactions=uid_redactions,
             fill_value=fill_value,
             now=now,
         )
 
-    _append_audit_record(cod_object, boxes, reviewer=reviewer, now=now)
+    _append_audit_record(cod_object, redactions, reviewer=reviewer, now=now)
 
 
-def _group_boxes_by_uid(
-    boxes: list[BoundingBox], instances: dict
-) -> dict[str, list[BoundingBox]]:
-    grouped: dict[str, list[BoundingBox]] = defaultdict(list)
-    for box in boxes:
-        for uid in box.applies_to:
+def _group_by_uid(
+    redactions: list[PixelRedaction], instances: dict
+) -> dict[str, list[PixelRedaction]]:
+    grouped: dict[str, list[PixelRedaction]] = defaultdict(list)
+    for r in redactions:
+        for uid in r.applies_to:
             if uid not in instances:
                 raise RedactionTargetMissingError(
-                    f"Bounding box targets instance {uid!r} which is not in the series. "
+                    f"Redaction targets instance {uid!r} which is not in the series. "
                     f"(known: {sorted(instances.keys())})"
                 )
-            grouped[uid].append(box)
+            grouped[uid].append(r)
     return grouped
 
 
-def _validate_box_set_against_header(
+def _validate_redactions_against_header(
     uid: str,
     ds: pydicom3.Dataset,
-    boxes: list[BoundingBox],
+    redactions: list[PixelRedaction],
     fill_value: Optional[FillValue],
 ) -> None:
     rows = int(ds.Rows)
@@ -117,7 +118,8 @@ def _validate_box_set_against_header(
 
     _validate_fill_value(uid, fill_value, samples, photometric)
 
-    for box in boxes:
+    for r in redactions:
+        box = r.box
         if box.x < 0 or box.y < 0 or box.width <= 0 or box.height <= 0:
             raise RedactionBoxOutOfBoundsError(
                 f"Instance {uid}: box {box} has non-positive width/height "
@@ -127,7 +129,7 @@ def _validate_box_set_against_header(
             raise RedactionBoxOutOfBoundsError(
                 f"Instance {uid}: box {box} not contained in frame ({cols}x{rows})"
             )
-        frames = box.frames if box.frames is not None else range(num_frames)
+        frames = r.frames if r.frames is not None else range(num_frames)
         for f in frames:
             if f < 0 or f >= num_frames:
                 raise RedactionFrameOutOfRangeError(
@@ -173,7 +175,7 @@ def _derive_fill_value(samples: int, pi: str, bits_stored: int) -> FillValue:
 
 def _apply_to_instance(
     instance: "Instance",
-    boxes: list[BoundingBox],
+    redactions: list[PixelRedaction],
     fill_value: Optional[FillValue],
     now: datetime.datetime,
 ) -> None:
@@ -208,23 +210,41 @@ def _apply_to_instance(
         else _derive_fill_value(samples, effective_pi, bits_stored)
     )
 
-    for box in boxes:
-        frames = box.frames if box.frames is not None else range(num_frames)
+    for r in redactions:
+        box = r.box
+        frames = r.frames if r.frames is not None else range(num_frames)
         for f in frames:
             framed[f, box.y : box.y + box.height, box.x : box.x + box.width] = fv
 
     _stamp_deid_tags(ds, now)
 
-    # Always normalize to JPEG 2000 Lossless. generate_instance_uid=False keeps
-    # SOPInstanceUID stable so mode='e' set-changed validation doesn't trip
-    # (pydicom would otherwise mint a fresh UID for any lossy encode).
-    ds.compress(JPEG2000Lossless, arr=arr, generate_instance_uid=False)
+    # Always normalize to JPEG 2000 Lossless (see module docstring for why).
+    # Lossless leaves SOPInstanceUID alone, which mode='e' set-changed validation
+    # relies on; pydicom only auto-regenerates the UID for lossy compresses.
+    ds.compress(JPEG2000Lossless, arr=arr)
     ds.save_as(instance.dicom_uri)
 
 
 def _stamp_deid_tags(ds: pydicom3.Dataset, now: datetime.datetime) -> None:
+    """Mark the instance as having had its pixel data scrubbed of PHI.
+
+    Three standard tags get touched. Each one is what downstream consumers
+    (PACS, research collaborators, compliance audits) look at to decide
+    whether the instance is safe to use.
+    """
+
+    # (0028,0301) BurnedInAnnotation: "is there PHI burned into the pixels?"
+    # Downstream tools gate sharing/release on this flag. After we redact, the
+    # answer is "NO"; without setting it, consumers continue to assume worst-
+    # case and the redaction has no externally-observable effect.
     ds.BurnedInAnnotation = "NO"
 
+    # (0012,0064) DeidentificationMethodCodeSequence: a list of coded entries
+    # from CID 7050 documenting *which* de-id methods ran. Code 113101 ("Clean
+    # Pixel Data Option") is the standard DICOM PS3.16 entry for what we just
+    # did. Required to claim Basic Confidentiality Profile compliance.
+    # Append rather than overwrite: upstream text/metadata de-id may have
+    # already added entries we mustn't clobber.
     method_item = pydicom3.Dataset()
     method_item.CodeValue = _DEID_METHOD_CODE
     method_item.CodingSchemeDesignator = _DEID_METHOD_DESIGNATOR
@@ -233,13 +253,17 @@ def _stamp_deid_tags(ds: pydicom3.Dataset, now: datetime.datetime) -> None:
     seq.append(method_item)
     ds.DeidentificationMethodCodeSequence = seq
 
+    # (0008,0012)/(0008,0013) InstanceCreationDate/Time: stamp the instance
+    # with the redaction time. Visible in any DICOM viewer (so a reviewer can
+    # see "this was modified") and used by downstream caches/dedupers that
+    # key on freshness.
     ds.InstanceCreationDate = now.strftime("%Y%m%d")
     ds.InstanceCreationTime = now.strftime("%H%M%S")
 
 
 def _append_audit_record(
     cod_object: "CODObject",
-    boxes: list[BoundingBox],
+    redactions: list[PixelRedaction],
     *,
     reviewer: str,
     now: datetime.datetime,
@@ -247,17 +271,7 @@ def _append_audit_record(
     record = {
         "timestamp": now.strftime("%Y-%m-%dT%H:%M:%SZ"),
         "reviewer": reviewer,
-        "entries": [
-            {
-                "x": b.x,
-                "y": b.y,
-                "width": b.width,
-                "height": b.height,
-                "applies_to": list(b.applies_to),
-                "frames": list(b.frames) if b.frames is not None else None,
-            }
-            for b in boxes
-        ],
+        "entries": [dataclasses.asdict(r) for r in redactions],
     }
     existing = cod_object._get_metadata_field("redactions") or []
     cod_object.add_metadata_field(

--- a/cloud_optimized_dicom/redact.py
+++ b/cloud_optimized_dicom/redact.py
@@ -15,6 +15,8 @@ in practice nothing's changing format for already-stored data.
 
 import dataclasses
 import datetime
+import os
+import tempfile
 from collections import defaultdict
 from typing import TYPE_CHECKING, Optional, Union
 
@@ -69,23 +71,30 @@ def redact_pixel_data(
     instances = cod_object._get_instances(strict_sorting=False)
     redactions_by_uid = _group_by_uid(redactions, instances)
 
-    # Pre-flight: read each affected instance's header (no pixel decode) and
-    # validate every redaction against it. Raises before any pixel data is
-    # decoded or written.
+    # Pre-flight: read each affected instance once with PixelData deferred,
+    # validate against the header, and stash the dataset for the apply pass
+    # so we don't dcmread the file twice. defer_size keeps each Dataset's
+    # in-memory footprint at header-only until the apply step calls
+    # ds.pixel_array, which avoids holding all instances' decoded pixel
+    # data simultaneously when N is large.
+    datasets: dict[str, pydicom3.Dataset] = {}
     for uid, uid_redactions in redactions_by_uid.items():
-        ds = pydicom3.dcmread(instances[uid].dicom_uri, stop_before_pixels=True)
+        ds = pydicom3.dcmread(instances[uid].dicom_uri, defer_size=1024)
         _validate_redactions_against_header(uid, ds, uid_redactions, fill_value)
+        datasets[uid] = ds
 
-    # Apply pass.
-    now = datetime.datetime.now(datetime.timezone.utc)
+    # Apply pass. Drop each dataset after its instance is rewritten so the
+    # decoded pixel data and any other materialized tags are eligible for GC.
     for uid, uid_redactions in redactions_by_uid.items():
         _apply_to_instance(
             instance=instances[uid],
+            ds=datasets[uid],
             redactions=uid_redactions,
             fill_value=fill_value,
-            now=now,
         )
+        del datasets[uid]
 
+    now = datetime.datetime.now(datetime.timezone.utc)
     _append_audit_record(cod_object, redactions, reviewer=reviewer, now=now)
 
 
@@ -175,11 +184,10 @@ def _derive_fill_value(samples: int, pi: str, bits_stored: int) -> FillValue:
 
 def _apply_to_instance(
     instance: "Instance",
+    ds: pydicom3.Dataset,
     redactions: list[PixelRedaction],
     fill_value: Optional[FillValue],
-    now: datetime.datetime,
 ) -> None:
-    ds = pydicom3.dcmread(instance.dicom_uri)
     original_pi = str(ds.PhotometricInterpretation)
     arr = ds.pixel_array
 
@@ -204,33 +212,49 @@ def _apply_to_instance(
     else:
         framed = arr
 
-    fv = (
-        fill_value
-        if fill_value is not None
-        else _derive_fill_value(samples, effective_pi, bits_stored)
-    )
+    if fill_value is None:
+        fill_value = _derive_fill_value(samples, effective_pi, bits_stored)
 
     for r in redactions:
         box = r.box
         frames = r.frames if r.frames is not None else range(num_frames)
         for f in frames:
-            framed[f, box.y : box.y + box.height, box.x : box.x + box.width] = fv
+            framed[f, box.y : box.y + box.height, box.x : box.x + box.width] = (
+                fill_value
+            )
 
-    _stamp_deid_tags(ds, now)
+    _stamp_deid_tags(ds)
 
     # Always normalize to JPEG 2000 Lossless (see module docstring for why).
     # Lossless leaves SOPInstanceUID alone, which mode='e' set-changed validation
     # relies on; pydicom only auto-regenerates the UID for lossy compresses.
     ds.compress(JPEG2000Lossless, arr=arr)
-    ds.save_as(instance.dicom_uri)
+
+    # Write to a sibling temp file then atomically rename. pydicom's save_as
+    # truncates the destination before iterating tags to write; if the
+    # destination is the same path we read from with defer_size, any tag
+    # pydicom hasn't materialized yet (e.g., a private tag above the defer
+    # threshold) would fail to deferred-read. Writing to a side path keeps
+    # the source intact until the rename.
+    target = instance.dicom_uri
+    fd, tmp = tempfile.mkstemp(dir=os.path.dirname(target), suffix=".dcm")
+    os.close(fd)
+    ds.save_as(tmp)
+    os.replace(tmp, target)
 
 
-def _stamp_deid_tags(ds: pydicom3.Dataset, now: datetime.datetime) -> None:
+def _stamp_deid_tags(ds: pydicom3.Dataset) -> None:
     """Mark the instance as having had its pixel data scrubbed of PHI.
 
-    Three standard tags get touched. Each one is what downstream consumers
+    Two standard tags get touched. Each one is what downstream consumers
     (PACS, research collaborators, compliance audits) look at to decide
     whether the instance is safe to use.
+
+    InstanceCreationDate/Time are deliberately left alone: those describe
+    when the SOP instance was originally created (acquisition/reconstruction
+    time, of clinical interest) and overwriting destroys that signal. The
+    redaction timestamp is preserved in the audit record under
+    metadata_fields["redactions"] instead.
     """
 
     # (0028,0301) BurnedInAnnotation: "is there PHI burned into the pixels?"
@@ -252,13 +276,6 @@ def _stamp_deid_tags(ds: pydicom3.Dataset, now: datetime.datetime) -> None:
     seq = list(getattr(ds, "DeidentificationMethodCodeSequence", []) or [])
     seq.append(method_item)
     ds.DeidentificationMethodCodeSequence = seq
-
-    # (0008,0012)/(0008,0013) InstanceCreationDate/Time: stamp the instance
-    # with the redaction time. Visible in any DICOM viewer (so a reviewer can
-    # see "this was modified") and used by downstream caches/dedupers that
-    # key on freshness.
-    ds.InstanceCreationDate = now.strftime("%Y%m%d")
-    ds.InstanceCreationTime = now.strftime("%H%M%S")
 
 
 def _append_audit_record(

--- a/cloud_optimized_dicom/redact.py
+++ b/cloud_optimized_dicom/redact.py
@@ -19,7 +19,6 @@ from typing import TYPE_CHECKING, Optional, Union
 
 import numpy as np
 import pydicom3
-from google.cloud import storage
 from pydicom3.uid import JPEG2000Lossless
 
 from cloud_optimized_dicom.bounding_box import BoundingBox
@@ -53,35 +52,6 @@ FillValue = Union[int, tuple[int, ...]]
 
 
 def redact_pixel_data(
-    client: storage.Client,
-    datastore_path: str,
-    study_uid: str,
-    series_uid: str,
-    boxes: list[BoundingBox],
-    *,
-    reviewer: str,
-    hashed_uids: bool = False,
-    fill_value: Optional[FillValue] = None,
-) -> None:
-    """Open the target series in mode='e' and apply pixel-data blackout boxes.
-
-    See `CODObject.redact_pixel_data` for the per-call validation rules. On any
-    failure, the lock is released and no remote changes are uploaded.
-    """
-    from cloud_optimized_dicom.cod_object import CODObject
-
-    with CODObject(
-        client=client,
-        datastore_path=datastore_path,
-        study_uid=study_uid,
-        series_uid=series_uid,
-        mode="e",
-        hashed_uids=hashed_uids,
-    ) as cod:
-        apply_redactions(cod, boxes, reviewer=reviewer, fill_value=fill_value)
-
-
-def apply_redactions(
     cod_object: "CODObject",
     boxes: list[BoundingBox],
     *,

--- a/cloud_optimized_dicom/redact.py
+++ b/cloud_optimized_dicom/redact.py
@@ -1,0 +1,295 @@
+"""Pixel-data redaction via mode='e'.
+
+Reviewer-supplied bounding boxes are blacked out in each target instance's
+PixelData, then the instance is re-encoded as JPEG 2000 Lossless. An audit
+record is appended to series-level metadata_fields["redactions"] so the
+action is traceable later.
+
+Output transfer syntax is fixed at JPEG 2000 Lossless regardless of the
+source TS. This: (a) sidesteps pydicom auto-regenerating SOPInstanceUID for
+lossy encodes (which would trip mode='e' set-changed validation), (b) lets
+us assume the encoder is always available since pylibjpeg-openjpeg is a
+hard dependency, and (c) matches what append.py already does on ingest, so
+in practice nothing's changing format for already-stored data.
+"""
+
+import datetime
+from collections import defaultdict
+from typing import TYPE_CHECKING, Optional, Union
+
+import numpy as np
+import pydicom3
+from google.cloud import storage
+from pydicom3.uid import JPEG2000Lossless
+
+from cloud_optimized_dicom.bounding_box import BoundingBox
+from cloud_optimized_dicom.errors import (
+    RedactionBoxOutOfBoundsError,
+    RedactionFillValueError,
+    RedactionFrameOutOfRangeError,
+    RedactionTargetMissingError,
+)
+
+if TYPE_CHECKING:
+    from cloud_optimized_dicom.cod_object import CODObject
+    from cloud_optimized_dicom.instance import Instance
+
+# DCM CID 7050 code for "Clean Pixel Data Option": what we record in
+# DeidentificationMethodCodeSequence to flag instances whose pixels were
+# scrubbed of PHI by this routine.
+_DEID_METHOD_CODE = "113101"
+_DEID_METHOD_DESIGNATOR = "DCM"
+_DEID_METHOD_MEANING = "Clean Pixel Data Option"
+
+# Photometric interpretations that pydicom's `pixel_array` auto-converts to
+# RGB on read (the JPEG decoders return RGB for these). After decode we
+# must update PhotometricInterpretation to match the decoded array, otherwise
+# the re-encoded bytes would be RGB but the header would still say YBR.
+_PI_AUTO_CONVERTS_TO_RGB = frozenset(
+    {"YBR_FULL", "YBR_FULL_422", "YBR_ICT", "YBR_PARTIAL_420", "YBR_PARTIAL_422"}
+)
+
+FillValue = Union[int, tuple[int, ...]]
+
+
+def redact_pixel_data(
+    client: storage.Client,
+    datastore_path: str,
+    study_uid: str,
+    series_uid: str,
+    boxes: list[BoundingBox],
+    *,
+    reviewer: str,
+    hashed_uids: bool = False,
+    fill_value: Optional[FillValue] = None,
+) -> None:
+    """Open the target series in mode='e' and apply pixel-data blackout boxes.
+
+    See `CODObject.redact_pixel_data` for the per-call validation rules. On any
+    failure, the lock is released and no remote changes are uploaded.
+    """
+    from cloud_optimized_dicom.cod_object import CODObject
+
+    with CODObject(
+        client=client,
+        datastore_path=datastore_path,
+        study_uid=study_uid,
+        series_uid=series_uid,
+        mode="e",
+        hashed_uids=hashed_uids,
+    ) as cod:
+        apply_redactions(cod, boxes, reviewer=reviewer, fill_value=fill_value)
+
+
+def apply_redactions(
+    cod_object: "CODObject",
+    boxes: list[BoundingBox],
+    *,
+    reviewer: str,
+    fill_value: Optional[FillValue] = None,
+) -> None:
+    """Body of `CODObject.redact_pixel_data`. See that method for docs."""
+    if cod_object.mode != "e":
+        raise ValueError(
+            f"redact_pixel_data() requires mode='e', got mode={cod_object.mode!r}. "
+            f"Edit mode is needed because redaction modifies existing pixel data in place."
+        )
+
+    instances = cod_object._get_instances(strict_sorting=False)
+    boxes_by_uid = _group_boxes_by_uid(boxes, instances)
+
+    # Pre-flight: read each affected instance's header (no pixel decode) and
+    # validate every box against it. Raises before any pixel data is decoded
+    # or written.
+    for uid, uid_boxes in boxes_by_uid.items():
+        ds = pydicom3.dcmread(instances[uid].dicom_uri, stop_before_pixels=True)
+        _validate_box_set_against_header(uid, ds, uid_boxes, fill_value)
+
+    # Apply pass.
+    now = datetime.datetime.now(datetime.timezone.utc)
+    for uid, uid_boxes in boxes_by_uid.items():
+        _apply_to_instance(
+            instance=instances[uid],
+            boxes=uid_boxes,
+            fill_value=fill_value,
+            now=now,
+        )
+
+    _append_audit_record(cod_object, boxes, reviewer=reviewer, now=now)
+
+
+def _group_boxes_by_uid(
+    boxes: list[BoundingBox], instances: dict
+) -> dict[str, list[BoundingBox]]:
+    grouped: dict[str, list[BoundingBox]] = defaultdict(list)
+    for box in boxes:
+        for uid in box.applies_to:
+            if uid not in instances:
+                raise RedactionTargetMissingError(
+                    f"Bounding box targets instance {uid!r} which is not in the series. "
+                    f"(known: {sorted(instances.keys())})"
+                )
+            grouped[uid].append(box)
+    return grouped
+
+
+def _validate_box_set_against_header(
+    uid: str,
+    ds: pydicom3.Dataset,
+    boxes: list[BoundingBox],
+    fill_value: Optional[FillValue],
+) -> None:
+    rows = int(ds.Rows)
+    cols = int(ds.Columns)
+    num_frames = int(getattr(ds, "NumberOfFrames", 1))
+    samples = int(getattr(ds, "SamplesPerPixel", 1))
+    photometric = str(ds.PhotometricInterpretation)
+
+    _validate_fill_value(uid, fill_value, samples, photometric)
+
+    for box in boxes:
+        if box.x < 0 or box.y < 0 or box.width <= 0 or box.height <= 0:
+            raise RedactionBoxOutOfBoundsError(
+                f"Instance {uid}: box {box} has non-positive width/height "
+                f"or negative origin"
+            )
+        if box.x + box.width > cols or box.y + box.height > rows:
+            raise RedactionBoxOutOfBoundsError(
+                f"Instance {uid}: box {box} not contained in frame ({cols}x{rows})"
+            )
+        frames = box.frames if box.frames is not None else range(num_frames)
+        for f in frames:
+            if f < 0 or f >= num_frames:
+                raise RedactionFrameOutOfRangeError(
+                    f"Instance {uid}: frame index {f} out of range "
+                    f"(NumberOfFrames={num_frames})"
+                )
+
+
+def _validate_fill_value(
+    uid: str,
+    fill_value: Optional[FillValue],
+    samples: int,
+    photometric: str,
+) -> None:
+    if fill_value is None:
+        return
+    if samples == 1:
+        if not isinstance(fill_value, int):
+            raise RedactionFillValueError(
+                f"Instance {uid}: SamplesPerPixel=1 requires int fill_value, "
+                f"got {fill_value!r}"
+            )
+    else:
+        if not isinstance(fill_value, tuple) or len(fill_value) != samples:
+            raise RedactionFillValueError(
+                f"Instance {uid}: SamplesPerPixel={samples} "
+                f"(PhotometricInterpretation={photometric!r}) requires a tuple "
+                f"fill_value of length {samples}, got {fill_value!r}"
+            )
+
+
+def _derive_fill_value(samples: int, pi: str, bits_stored: int) -> FillValue:
+    """Default fill is whatever displays as black for the (post-decode)
+    PhotometricInterpretation. Color sources all end up as either RGB (after
+    pydicom auto-converts the YBR_FULL family) or YBR_RCT, both of which
+    treat (0, 0, 0) as black, so a single value covers every color path."""
+    if samples == 1:
+        if pi == "MONOCHROME1":
+            return (1 << bits_stored) - 1
+        return 0
+    return (0, 0, 0)
+
+
+def _apply_to_instance(
+    instance: "Instance",
+    boxes: list[BoundingBox],
+    fill_value: Optional[FillValue],
+    now: datetime.datetime,
+) -> None:
+    ds = pydicom3.dcmread(instance.dicom_uri)
+    original_pi = str(ds.PhotometricInterpretation)
+    arr = ds.pixel_array
+
+    num_frames = int(getattr(ds, "NumberOfFrames", 1))
+    samples = int(getattr(ds, "SamplesPerPixel", 1))
+    bits_stored = int(getattr(ds, "BitsStored", 8))
+
+    # If pydicom converted YBR -> RGB on decode, the array is RGB even though
+    # the header still says YBR. Reflect that on the dataset before compress
+    # so the re-encoded bytes match the PhotometricInterpretation tag.
+    effective_pi = "RGB" if original_pi in _PI_AUTO_CONVERTS_TO_RGB else original_pi
+    if effective_pi != original_pi:
+        ds.PhotometricInterpretation = effective_pi
+
+    # pixel_array drops the leading frame axis when NumberOfFrames is 1 or
+    # absent. Add a synthetic axis so the slice below works uniformly; the
+    # view shares memory with arr so writes hit the original buffer.
+    if num_frames == 1 and (
+        (samples == 1 and arr.ndim == 2) or (samples > 1 and arr.ndim == 3)
+    ):
+        framed = arr[np.newaxis, ...]
+    else:
+        framed = arr
+
+    fv = (
+        fill_value
+        if fill_value is not None
+        else _derive_fill_value(samples, effective_pi, bits_stored)
+    )
+
+    for box in boxes:
+        frames = box.frames if box.frames is not None else range(num_frames)
+        for f in frames:
+            framed[f, box.y : box.y + box.height, box.x : box.x + box.width] = fv
+
+    _stamp_deid_tags(ds, now)
+
+    # Always normalize to JPEG 2000 Lossless. generate_instance_uid=False keeps
+    # SOPInstanceUID stable so mode='e' set-changed validation doesn't trip
+    # (pydicom would otherwise mint a fresh UID for any lossy encode).
+    ds.compress(JPEG2000Lossless, arr=arr, generate_instance_uid=False)
+    ds.save_as(instance.dicom_uri)
+
+
+def _stamp_deid_tags(ds: pydicom3.Dataset, now: datetime.datetime) -> None:
+    ds.BurnedInAnnotation = "NO"
+
+    method_item = pydicom3.Dataset()
+    method_item.CodeValue = _DEID_METHOD_CODE
+    method_item.CodingSchemeDesignator = _DEID_METHOD_DESIGNATOR
+    method_item.CodeMeaning = _DEID_METHOD_MEANING
+    seq = list(getattr(ds, "DeidentificationMethodCodeSequence", []) or [])
+    seq.append(method_item)
+    ds.DeidentificationMethodCodeSequence = seq
+
+    ds.InstanceCreationDate = now.strftime("%Y%m%d")
+    ds.InstanceCreationTime = now.strftime("%H%M%S")
+
+
+def _append_audit_record(
+    cod_object: "CODObject",
+    boxes: list[BoundingBox],
+    *,
+    reviewer: str,
+    now: datetime.datetime,
+) -> None:
+    record = {
+        "timestamp": now.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "reviewer": reviewer,
+        "entries": [
+            {
+                "x": b.x,
+                "y": b.y,
+                "width": b.width,
+                "height": b.height,
+                "applies_to": list(b.applies_to),
+                "frames": list(b.frames) if b.frames is not None else None,
+            }
+            for b in boxes
+        ],
+    }
+    existing = cod_object._get_metadata_field("redactions") or []
+    cod_object.add_metadata_field(
+        "redactions", existing + [record], overwrite_existing=True
+    )

--- a/cloud_optimized_dicom/tests/test_redact.py
+++ b/cloud_optimized_dicom/tests/test_redact.py
@@ -1,0 +1,92 @@
+"""Smoke-level integration tests for pixel-data redaction via mode='e'.
+
+Covers: redaction works end-to-end, output is normalized to JPEG 2000
+Lossless with a stable SOPInstanceUID, and the API is mode-guarded.
+Comprehensive edge-case coverage (audit trail accumulation, multiframe
+frame-selection, hard-error paths, free-function entry point) lives in a
+follow-up PR stacked on top of this one.
+"""
+
+import numpy as np
+import pydicom3
+import pytest
+
+from cloud_optimized_dicom.bounding_box import BoundingBox
+from cloud_optimized_dicom.errors import WriteOperationInReadModeError
+from cloud_optimized_dicom.tests.conftest import SeriesHandle
+
+
+def _read_remote_pixel_array(handle: SeriesHandle, instance_uid: str) -> np.ndarray:
+    """Pull the series tar fresh from GCS, return the pixel_array of the named instance."""
+    with handle.open(mode="r") as cod:
+        cod.extract_locally()
+        instance = cod._get_instance(instance_uid)
+        return pydicom3.dcmread(instance.dicom_uri).pixel_array
+
+
+def _read_remote_dataset(handle: SeriesHandle, instance_uid: str) -> pydicom3.Dataset:
+    with handle.open(mode="r") as cod:
+        cod.extract_locally()
+        instance = cod._get_instance(instance_uid)
+        return pydicom3.dcmread(instance.dicom_uri)
+
+
+def test_redact_single_frame_happy_path(seeded_series: SeriesHandle):
+    """Redacting one box on one instance zeros that region and leaves the
+    rest of the series alone."""
+    with seeded_series.open(mode="r") as cod:
+        uids = list(cod._get_instances(strict_sorting=False).keys())
+    target_uid, untouched_uid = uids[0], uids[1]
+
+    before_target = _read_remote_pixel_array(seeded_series, target_uid)
+    before_untouched = _read_remote_pixel_array(seeded_series, untouched_uid)
+
+    box = BoundingBox(x=10, y=20, width=30, height=40, applies_to=[target_uid])
+
+    with seeded_series.open(mode="e") as cod:
+        cod.redact_pixel_data([box], reviewer="reviewer-a@gradienthealth.io")
+
+    after_target = _read_remote_pixel_array(seeded_series, target_uid)
+    after_untouched = _read_remote_pixel_array(seeded_series, untouched_uid)
+
+    redacted_region = after_target[20:60, 10:40]
+    assert np.all(redacted_region == 0), "redacted region should be zero (MONOCHROME2)"
+
+    # Pixels outside the redaction box must match the original exactly
+    # (JPEG 2000 Lossless round-trip is bit-exact).
+    mask = np.ones_like(after_target, dtype=bool)
+    mask[20:60, 10:40] = False
+    assert np.array_equal(after_target[mask], before_target[mask])
+
+    assert np.array_equal(after_untouched, before_untouched)
+
+
+def test_redact_outputs_j2k_lossless_with_stable_sop_uid(
+    seeded_series: SeriesHandle,
+):
+    """Output TS is fixed at JPEG 2000 Lossless and SOPInstanceUID is stable
+    across the redact (regression: pydicom auto-regenerates the SOP UID for
+    lossy compress() calls, which would trip mode='e' set-changed validation;
+    we pass generate_instance_uid=False to suppress that)."""
+    with seeded_series.open(mode="r") as cod:
+        target_uid = next(iter(cod._get_instances(strict_sorting=False)))
+
+    pre = _read_remote_dataset(seeded_series, target_uid)
+    sop_before = pre.SOPInstanceUID
+
+    box = BoundingBox(x=0, y=0, width=10, height=10, applies_to=[target_uid])
+    with seeded_series.open(mode="e") as cod:
+        cod.redact_pixel_data([box], reviewer="ts-test@gradienthealth.io")
+
+    post = _read_remote_dataset(seeded_series, target_uid)
+    assert str(post.file_meta.TransferSyntaxUID) == "1.2.840.10008.1.2.4.90"
+    assert post.SOPInstanceUID == sop_before
+
+
+def test_redact_in_read_mode_raises(seeded_series: SeriesHandle):
+    """The public_method(write_only=True) decorator blocks read-mode calls."""
+    with seeded_series.open(mode="r") as cod:
+        target_uid = next(iter(cod._get_instances(strict_sorting=False)))
+        box = BoundingBox(x=0, y=0, width=5, height=5, applies_to=[target_uid])
+        with pytest.raises(WriteOperationInReadModeError):
+            cod.redact_pixel_data([box], reviewer="r")

--- a/cloud_optimized_dicom/tests/test_redact.py
+++ b/cloud_optimized_dicom/tests/test_redact.py
@@ -3,8 +3,8 @@
 Covers: redaction works end-to-end, output is normalized to JPEG 2000
 Lossless with a stable SOPInstanceUID, and the API is mode-guarded.
 Comprehensive edge-case coverage (audit trail accumulation, multiframe
-frame-selection, hard-error paths, free-function entry point) lives in a
-follow-up PR stacked on top of this one.
+frame-selection, hard-error paths) lives in a follow-up PR stacked on
+top of this one.
 """
 
 import numpy as np
@@ -16,19 +16,16 @@ from cloud_optimized_dicom.errors import WriteOperationInReadModeError
 from cloud_optimized_dicom.tests.conftest import SeriesHandle
 
 
-def _read_remote_pixel_array(handle: SeriesHandle, instance_uid: str) -> np.ndarray:
-    """Pull the series tar fresh from GCS, return the pixel_array of the named instance."""
-    with handle.open(mode="r") as cod:
-        cod.extract_locally()
-        instance = cod._get_instance(instance_uid)
-        return pydicom3.dcmread(instance.dicom_uri).pixel_array
-
-
 def _read_remote_dataset(handle: SeriesHandle, instance_uid: str) -> pydicom3.Dataset:
+    """Pull the series tar fresh from GCS and return the named instance as a Dataset."""
     with handle.open(mode="r") as cod:
         cod.extract_locally()
         instance = cod._get_instance(instance_uid)
         return pydicom3.dcmread(instance.dicom_uri)
+
+
+def _read_remote_pixel_array(handle: SeriesHandle, instance_uid: str) -> np.ndarray:
+    return _read_remote_dataset(handle, instance_uid).pixel_array
 
 
 def test_redact_single_frame_happy_path(seeded_series: SeriesHandle):

--- a/cloud_optimized_dicom/tests/test_redact.py
+++ b/cloud_optimized_dicom/tests/test_redact.py
@@ -11,7 +11,7 @@ import numpy as np
 import pydicom3
 import pytest
 
-from cloud_optimized_dicom.bounding_box import BoundingBox
+from cloud_optimized_dicom.bounding_box import BoundingBox, PixelRedaction
 from cloud_optimized_dicom.errors import WriteOperationInReadModeError
 from cloud_optimized_dicom.tests.conftest import SeriesHandle
 
@@ -38,10 +38,13 @@ def test_redact_single_frame_happy_path(seeded_series: SeriesHandle):
     before_target = _read_remote_pixel_array(seeded_series, target_uid)
     before_untouched = _read_remote_pixel_array(seeded_series, untouched_uid)
 
-    box = BoundingBox(x=10, y=20, width=30, height=40, applies_to=[target_uid])
+    redaction = PixelRedaction(
+        box=BoundingBox(x=10, y=20, width=30, height=40),
+        applies_to=[target_uid],
+    )
 
     with seeded_series.open(mode="e") as cod:
-        cod.redact_pixel_data([box], reviewer="reviewer-a@gradienthealth.io")
+        cod.redact_pixel_data([redaction], reviewer="reviewer-a@gradienthealth.io")
 
     after_target = _read_remote_pixel_array(seeded_series, target_uid)
     after_untouched = _read_remote_pixel_array(seeded_series, untouched_uid)
@@ -61,19 +64,21 @@ def test_redact_single_frame_happy_path(seeded_series: SeriesHandle):
 def test_redact_outputs_j2k_lossless_with_stable_sop_uid(
     seeded_series: SeriesHandle,
 ):
-    """Output TS is fixed at JPEG 2000 Lossless and SOPInstanceUID is stable
-    across the redact (regression: pydicom auto-regenerates the SOP UID for
-    lossy compress() calls, which would trip mode='e' set-changed validation;
-    we pass generate_instance_uid=False to suppress that)."""
+    """Output TS is JPEG 2000 Lossless and SOPInstanceUID is stable across the
+    redact. If the implementation ever switches to a lossy transfer syntax,
+    pydicom would auto-regenerate the SOP UID and trip mode='e' set-changed
+    validation; this test guards that invariant."""
     with seeded_series.open(mode="r") as cod:
         target_uid = next(iter(cod._get_instances(strict_sorting=False)))
 
     pre = _read_remote_dataset(seeded_series, target_uid)
     sop_before = pre.SOPInstanceUID
 
-    box = BoundingBox(x=0, y=0, width=10, height=10, applies_to=[target_uid])
+    redaction = PixelRedaction(
+        box=BoundingBox(x=0, y=0, width=10, height=10), applies_to=[target_uid]
+    )
     with seeded_series.open(mode="e") as cod:
-        cod.redact_pixel_data([box], reviewer="ts-test@gradienthealth.io")
+        cod.redact_pixel_data([redaction], reviewer="ts-test@gradienthealth.io")
 
     post = _read_remote_dataset(seeded_series, target_uid)
     assert str(post.file_meta.TransferSyntaxUID) == "1.2.840.10008.1.2.4.90"
@@ -84,6 +89,8 @@ def test_redact_in_read_mode_raises(seeded_series: SeriesHandle):
     """The public_method(write_only=True) decorator blocks read-mode calls."""
     with seeded_series.open(mode="r") as cod:
         target_uid = next(iter(cod._get_instances(strict_sorting=False)))
-        box = BoundingBox(x=0, y=0, width=5, height=5, applies_to=[target_uid])
+        redaction = PixelRedaction(
+            box=BoundingBox(x=0, y=0, width=5, height=5), applies_to=[target_uid]
+        )
         with pytest.raises(WriteOperationInReadModeError):
-            cod.redact_pixel_data([box], reviewer="r")
+            cod.redact_pixel_data([redaction], reviewer="r")


### PR DESCRIPTION
Stacked PR. Depends on #126 (BoundingBox dataclass) and #128 (conftest lift). Comprehensive test coverage in #129.

Lets reviewers permanently black out PHI regions that our de-identification pipeline misses by handing bounding boxes (in raw PixelData coordinates) to COD's existing mode='e'. Unlocks the human-in-the-loop redaction step the review service needs.

Usage mirrors `append`/`edit`: open the series in `mode='e'` and call the method.

```python
with CODObject(client=..., datastore_path=..., study_uid=..., series_uid=..., mode="e") as cod:
    cod.redact_pixel_data(boxes, reviewer="reviewer@gradienthealth.io")
```

- New `CODObject.redact_pixel_data` method (delegates to `redact.py:redact_pixel_data`, same pattern as `append`). Decodes, fills, re-encodes as **JPEG 2000 Lossless** (regardless of source TS), and stamps `BurnedInAnnotation = "NO"` plus a `DeidentificationMethodCodeSequence` entry (DCM 113101 "Clean Pixel Data Option").
- Audit trail: each call appends `{timestamp, reviewer, entries: [...boxes]}` to series-level `metadata_fields["redactions"]`, which survives edit-mode rebuild.
- Hard-fails before any disk write on: missing UID, out-of-range frame, oversized box, or `fill_value` incompatible with `PhotometricInterpretation`/`SamplesPerPixel`. Lock release on raise is unchanged from existing edit-mode behavior, so partial state cannot reach the datastore.
- New `RedactionError` hierarchy in `errors.py`.

**Test scope:** smoke-level only (single-frame happy path, output TS + SOP UID regression, read-mode rejection). Edge-case coverage for audit accumulation, multiframe frame selection, and every hard-error path lives in #129.

**Output TS policy:** redacted instances are normalized to JPEG 2000 Lossless rather than preserving the source transfer syntax. This sidesteps two pydicom behaviors that would otherwise corrupt results: (1) lossy `compress()` regenerates `SOPInstanceUID`, tripping mode='e' set-changed validation; (2) `pixel_array` auto-converts the YBR_FULL family to RGB on decode, so the source PhotometricInterpretation no longer matches the array bytes. Output normalization also matches what `append.py` already does on ingest, so in practice nothing's changing format for data already in COD, and `pylibjpeg-openjpeg` is a hard dep so the encoder is always available.