### PR TITLE
feat(PROC-1576): redact pixel data via bounding boxes in edit mode

### DIFF
--- a/cloud_optimized_dicom/cod_object.py
+++ b/cloud_optimized_dicom/cod_object.py
@@ -14,6 +14,7 @@ from ratarmountcore.mountsource.factory import open_mount_source as rmc_open
 
 import cloud_optimized_dicom.metrics as metrics
 from cloud_optimized_dicom.append import append
+from cloud_optimized_dicom.bounding_box import BoundingBox
 from cloud_optimized_dicom.config import logger
 from cloud_optimized_dicom.edit import EditState, _validate_and_repack_for_edit
 from cloud_optimized_dicom.errors import (
@@ -27,6 +28,7 @@ from cloud_optimized_dicom.errors import (
 )
 from cloud_optimized_dicom.instance import Instance
 from cloud_optimized_dicom.locker import CODLocker
+from cloud_optimized_dicom.redact import FillValue, apply_redactions
 from cloud_optimized_dicom.series_metadata import SeriesMetadata
 from cloud_optimized_dicom.thumbnail import (
     DEFAULT_SIZE,
@@ -440,6 +442,42 @@ class CODObject:
             max_series_size=max_series_size,
             compress=compress,
         )
+
+    @public_method(write_only=True)
+    def redact_pixel_data(
+        self,
+        boxes: list[BoundingBox],
+        *,
+        reviewer: str,
+        fill_value: Optional[FillValue] = None,
+    ) -> None:
+        """Black out pixel-data regions on instances in this series.
+
+        Must be called inside a `mode='e'` context. Each `BoundingBox` is
+        applied to its `applies_to` instance UIDs (and the listed `frames`,
+        or all frames if `frames is None`); affected instances are
+        re-encoded with their original transfer syntax. An audit record is
+        appended to series-level `metadata_fields["redactions"]`.
+
+        Hard-fails before any disk write if any of the following hold:
+
+        * A `BoundingBox.applies_to` UID is not present in this series.
+        * A `BoundingBox.frames` index is out of range for its instance.
+        * A `BoundingBox` is not fully contained in the target frame's
+          `(Rows, Columns)`.
+        * The original transfer syntax has no usable encoder installed.
+        * `fill_value` is incompatible with the target's
+          `PhotometricInterpretation` / `SamplesPerPixel`.
+
+        Args:
+            boxes: Bounding boxes to apply.
+            reviewer: Identifier of the human reviewer who requested the
+                redaction; recorded verbatim in the audit trail.
+            fill_value: Pixel value used to fill each box. If None, defaults
+                to whatever displays as black for the dataset's
+                PhotometricInterpretation (e.g. 0 for MONOCHROME2).
+        """
+        apply_redactions(self, boxes, reviewer=reviewer, fill_value=fill_value)
 
     def _sync(self, tar_storage_class: str = STANDARD_STORAGE_CLASS):
         """Private: Sync tar+index and/or metadata to GCS, as needed.

--- a/cloud_optimized_dicom/errors.py
+++ b/cloud_optimized_dicom/errors.py
@@ -58,3 +58,24 @@ class InstanceValidationError(CODError):
 class EditSetChangedError(CODError):
     """Exception raised on exit from mode='e' when the instance set changed during
     the edit (a DICOM file was deleted/moved/renamed, or its UIDs were mutated)."""
+
+
+class RedactionError(CODError):
+    """Base class for pixel-data redaction failures (see redact.py)."""
+
+
+class RedactionTargetMissingError(RedactionError):
+    """A bbox.applies_to UID does not exist in the target series."""
+
+
+class RedactionFrameOutOfRangeError(RedactionError):
+    """A bbox.frames index is out of range for its target instance."""
+
+
+class RedactionBoxOutOfBoundsError(RedactionError):
+    """A bbox is not fully contained in (Rows, Columns) of its target frame."""
+
+
+class RedactionFillValueError(RedactionError):
+    """The provided fill_value is incompatible with the target's PhotometricInterpretation
+    or SamplesPerPixel."""

--- a/cloud_optimized_dicom/redact.py
+++ b/cloud_optimized_dicom/redact.py
@@ -1,0 +1,295 @@
+"""Pixel-data redaction via mode='e'.
+
+Reviewer-supplied bounding boxes are blacked out in each target instance's
+PixelData, then the instance is re-encoded as JPEG 2000 Lossless. An audit
+record is appended to series-level metadata_fields["redactions"] so the
+action is traceable later.
+
+Output transfer syntax is fixed at JPEG 2000 Lossless regardless of the
+source TS. This: (a) sidesteps pydicom auto-regenerating SOPInstanceUID for
+lossy encodes (which would trip mode='e' set-changed validation), (b) lets
+us assume the encoder is always available since pylibjpeg-openjpeg is a
+hard dependency, and (c) matches what append.py already does on ingest, so
+in practice nothing's changing format for already-stored data.
+"""
+
+import datetime
+from collections import defaultdict
+from typing import TYPE_CHECKING, Optional, Union
+
+import numpy as np
+import pydicom3
+from google.cloud import storage
+from pydicom3.uid import JPEG2000Lossless
+
+from cloud_optimized_dicom.bounding_box import BoundingBox
+from cloud_optimized_dicom.errors import (
+    RedactionBoxOutOfBoundsError,
+    RedactionFillValueError,
+    RedactionFrameOutOfRangeError,
+    RedactionTargetMissingError,
+)
+
+if TYPE_CHECKING:
+    from cloud_optimized_dicom.cod_object import CODObject
+    from cloud_optimized_dicom.instance import Instance
+
+# DCM CID 7050 code for "Clean Pixel Data Option": what we record in
+# DeidentificationMethodCodeSequence to flag instances whose pixels were
+# scrubbed of PHI by this routine.
+_DEID_METHOD_CODE = "113101"
+_DEID_METHOD_DESIGNATOR = "DCM"
+_DEID_METHOD_MEANING = "Clean Pixel Data Option"
+
+# Photometric interpretations that pydicom's `pixel_array` auto-converts to
+# RGB on read (the JPEG decoders return RGB for these). After decode we
+# must update PhotometricInterpretation to match the decoded array, otherwise
+# the re-encoded bytes would be RGB but the header would still say YBR.
+_PI_AUTO_CONVERTS_TO_RGB = frozenset(
+    {"YBR_FULL", "YBR_FULL_422", "YBR_ICT", "YBR_PARTIAL_420", "YBR_PARTIAL_422"}
+)
+
+FillValue = Union[int, tuple[int, ...]]
+
+
+def redact_pixel_data(
+    client: storage.Client,
+    datastore_path: str,
+    study_uid: str,
+    series_uid: str,
+    boxes: list[BoundingBox],
+    *,
+    reviewer: str,
+    hashed_uids: bool = False,
+    fill_value: Optional[FillValue] = None,
+) -> None:
+    """Open the target series in mode='e' and apply pixel-data blackout boxes.
+
+    See `CODObject.redact_pixel_data` for the per-call validation rules. On any
+    failure, the lock is released and no remote changes are uploaded.
+    """
+    from cloud_optimized_dicom.cod_object import CODObject
+
+    with CODObject(
+        client=client,
+        datastore_path=datastore_path,
+        study_uid=study_uid,
+        series_uid=series_uid,
+        mode="e",
+        hashed_uids=hashed_uids,
+    ) as cod:
+        apply_redactions(cod, boxes, reviewer=reviewer, fill_value=fill_value)
+
+
+def apply_redactions(
+    cod_object: "CODObject",
+    boxes: list[BoundingBox],
+    *,
+    reviewer: str,
+    fill_value: Optional[FillValue] = None,
+) -> None:
+    """Body of `CODObject.redact_pixel_data`. See that method for docs."""
+    if cod_object.mode != "e":
+        raise ValueError(
+            f"redact_pixel_data() requires mode='e', got mode={cod_object.mode!r}. "
+            f"Edit mode is needed because redaction modifies existing pixel data in place."
+        )
+
+    instances = cod_object._get_instances(strict_sorting=False)
+    boxes_by_uid = _group_boxes_by_uid(boxes, instances)
+
+    # Pre-flight: read each affected instance's header (no pixel decode) and
+    # validate every box against it. Raises before any pixel data is decoded
+    # or written.
+    for uid, uid_boxes in boxes_by_uid.items():
+        ds = pydicom3.dcmread(instances[uid].dicom_uri, stop_before_pixels=True)
+        _validate_box_set_against_header(uid, ds, uid_boxes, fill_value)
+
+    # Apply pass.
+    now = datetime.datetime.now(datetime.timezone.utc)
+    for uid, uid_boxes in boxes_by_uid.items():
+        _apply_to_instance(
+            instance=instances[uid],
+            boxes=uid_boxes,
+            fill_value=fill_value,
+            now=now,
+        )
+
+    _append_audit_record(cod_object, boxes, reviewer=reviewer, now=now)
+
+
+def _group_boxes_by_uid(
+    boxes: list[BoundingBox], instances: dict
+) -> dict[str, list[BoundingBox]]:
+    grouped: dict[str, list[BoundingBox]] = defaultdict(list)
+    for box in boxes:
+        for uid in box.applies_to:
+            if uid not in instances:
+                raise RedactionTargetMissingError(
+                    f"Bounding box targets instance {uid!r} which is not in the series. "
+                    f"(known: {sorted(instances.keys())})"
+                )
+            grouped[uid].append(box)
+    return grouped
+
+
+def _validate_box_set_against_header(
+    uid: str,
+    ds: pydicom3.Dataset,
+    boxes: list[BoundingBox],
+    fill_value: Optional[FillValue],
+) -> None:
+    rows = int(ds.Rows)
+    cols = int(ds.Columns)
+    num_frames = int(getattr(ds, "NumberOfFrames", 1))
+    samples = int(getattr(ds, "SamplesPerPixel", 1))
+    photometric = str(ds.PhotometricInterpretation)
+
+    _validate_fill_value(uid, fill_value, samples, photometric)
+
+    for box in boxes:
+        if box.x < 0 or box.y < 0 or box.width <= 0 or box.height <= 0:
+            raise RedactionBoxOutOfBoundsError(
+                f"Instance {uid}: box {box} has non-positive width/height "
+                f"or negative origin"
+            )
+        if box.x + box.width > cols or box.y + box.height > rows:
+            raise RedactionBoxOutOfBoundsError(
+                f"Instance {uid}: box {box} not contained in frame ({cols}x{rows})"
+            )
+        frames = box.frames if box.frames is not None else range(num_frames)
+        for f in frames:
+            if f < 0 or f >= num_frames:
+                raise RedactionFrameOutOfRangeError(
+                    f"Instance {uid}: frame index {f} out of range "
+                    f"(NumberOfFrames={num_frames})"
+                )
+
+
+def _validate_fill_value(
+    uid: str,
+    fill_value: Optional[FillValue],
+    samples: int,
+    photometric: str,
+) -> None:
+    if fill_value is None:
+        return
+    if samples == 1:
+        if not isinstance(fill_value, int):
+            raise RedactionFillValueError(
+                f"Instance {uid}: SamplesPerPixel=1 requires int fill_value, "
+                f"got {fill_value!r}"
+            )
+    else:
+        if not isinstance(fill_value, tuple) or len(fill_value) != samples:
+            raise RedactionFillValueError(
+                f"Instance {uid}: SamplesPerPixel={samples} "
+                f"(PhotometricInterpretation={photometric!r}) requires a tuple "
+                f"fill_value of length {samples}, got {fill_value!r}"
+            )
+
+
+def _derive_fill_value(samples: int, pi: str, bits_stored: int) -> FillValue:
+    """Default fill is whatever displays as black for the (post-decode)
+    PhotometricInterpretation. Color sources all end up as either RGB (after
+    pydicom auto-converts the YBR_FULL family) or YBR_RCT, both of which
+    treat (0, 0, 0) as black, so a single value covers every color path."""
+    if samples == 1:
+        if pi == "MONOCHROME1":
+            return (1 << bits_stored) - 1
+        return 0
+    return (0, 0, 0)
+
+
+def _apply_to_instance(
+    instance: "Instance",
+    boxes: list[BoundingBox],
+    fill_value: Optional[FillValue],
+    now: datetime.datetime,
+) -> None:
+    ds = pydicom3.dcmread(instance.dicom_uri)
+    original_pi = str(ds.PhotometricInterpretation)
+    arr = ds.pixel_array
+
+    num_frames = int(getattr(ds, "NumberOfFrames", 1))
+    samples = int(getattr(ds, "SamplesPerPixel", 1))
+    bits_stored = int(getattr(ds, "BitsStored", 8))
+
+    # If pydicom converted YBR -> RGB on decode, the array is RGB even though
+    # the header still says YBR. Reflect that on the dataset before compress
+    # so the re-encoded bytes match the PhotometricInterpretation tag.
+    effective_pi = "RGB" if original_pi in _PI_AUTO_CONVERTS_TO_RGB else original_pi
+    if effective_pi != original_pi:
+        ds.PhotometricInterpretation = effective_pi
+
+    # pixel_array drops the leading frame axis when NumberOfFrames is 1 or
+    # absent. Add a synthetic axis so the slice below works uniformly; the
+    # view shares memory with arr so writes hit the original buffer.
+    if num_frames == 1 and (
+        (samples == 1 and arr.ndim == 2) or (samples > 1 and arr.ndim == 3)
+    ):
+        framed = arr[np.newaxis, ...]
+    else:
+        framed = arr
+
+    fv = (
+        fill_value
+        if fill_value is not None
+        else _derive_fill_value(samples, effective_pi, bits_stored)
+    )
+
+    for box in boxes:
+        frames = box.frames if box.frames is not None else range(num_frames)
+        for f in frames:
+            framed[f, box.y : box.y + box.height, box.x : box.x + box.width] = fv
+
+    _stamp_deid_tags(ds, now)
+
+    # Always normalize to JPEG 2000 Lossless. generate_instance_uid=False keeps
+    # SOPInstanceUID stable so mode='e' set-changed validation doesn't trip
+    # (pydicom would otherwise mint a fresh UID for any lossy encode).
+    ds.compress(JPEG2000Lossless, arr=arr, generate_instance_uid=False)
+    ds.save_as(instance.dicom_uri)
+
+
+def _stamp_deid_tags(ds: pydicom3.Dataset, now: datetime.datetime) -> None:
+    ds.BurnedInAnnotation = "NO"
+
+    method_item = pydicom3.Dataset()
+    method_item.CodeValue = _DEID_METHOD_CODE
+    method_item.CodingSchemeDesignator = _DEID_METHOD_DESIGNATOR
+    method_item.CodeMeaning = _DEID_METHOD_MEANING
+    seq = list(getattr(ds, "DeidentificationMethodCodeSequence", []) or [])
+    seq.append(method_item)
+    ds.DeidentificationMethodCodeSequence = seq
+
+    ds.InstanceCreationDate = now.strftime("%Y%m%d")
+    ds.InstanceCreationTime = now.strftime("%H%M%S")
+
+
+def _append_audit_record(
+    cod_object: "CODObject",
+    boxes: list[BoundingBox],
+    *,
+    reviewer: str,
+    now: datetime.datetime,
+) -> None:
+    record = {
+        "timestamp": now.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "reviewer": reviewer,
+        "entries": [
+            {
+                "x": b.x,
+                "y": b.y,
+                "width": b.width,
+                "height": b.height,
+                "applies_to": list(b.applies_to),
+                "frames": list(b.frames) if b.frames is not None else None,
+            }
+            for b in boxes
+        ],
+    }
+    existing = cod_object._get_metadata_field("redactions") or []
+    cod_object.add_metadata_field(
+        "redactions", existing + [record], overwrite_existing=True
+    )

--- a/cloud_optimized_dicom/tests/conftest.py
+++ b/cloud_optimized_dicom/tests/conftest.py
@@ -1,9 +1,13 @@
 import os
+from dataclasses import dataclass
+from typing import Literal
 
 import pytest
 from google.api_core.client_options import ClientOptions
 from google.cloud import storage
 
+from cloud_optimized_dicom.cod_object import CODObject
+from cloud_optimized_dicom.instance import Instance
 from cloud_optimized_dicom.utils import delete_uploaded_blobs
 
 GCP_PROJECT = "gradient-pacs-siskin-172863"
@@ -61,3 +65,65 @@ def test_series_uid() -> str:
 @pytest.fixture(scope="session")
 def test_study_uid() -> str:
     return TEST_STUDY_UID
+
+
+@dataclass
+class SeriesHandle:
+    """Bundles the four sticky CODObject args so tests can `.open(mode=...)`
+    without re-typing client/datastore_path/study_uid/series_uid every call."""
+
+    client: storage.Client
+    datastore_path: str
+    study_uid: str
+    series_uid: str
+
+    def open(self, mode: Literal["r", "w", "a", "e"], **kwargs) -> CODObject:
+        return CODObject(
+            client=self.client,
+            datastore_path=self.datastore_path,
+            study_uid=self.study_uid,
+            series_uid=self.series_uid,
+            mode=mode,
+            **kwargs,
+        )
+
+
+@pytest.fixture(scope="module")
+def series_dir(test_data_dir: str) -> str:
+    return os.path.join(test_data_dir, "series")
+
+
+@pytest.fixture(scope="module")
+def series_files(series_dir: str) -> list[str]:
+    """First two .dcm files in the series fixture directory."""
+    return sorted(
+        os.path.join(series_dir, f)
+        for f in os.listdir(series_dir)
+        if f.endswith(".dcm")
+    )[:2]
+
+
+@pytest.fixture(scope="module")
+def series_uids(series_files: list[str]) -> tuple[str, str]:
+    """Probe (study_uid, series_uid) from the first series file."""
+    probe = Instance(dicom_uri=series_files[0])
+    return probe.study_uid(), probe.series_uid()
+
+
+@pytest.fixture
+def fresh_series(
+    gcs_client: storage.Client,
+    datastore_path: str,
+    series_uids: tuple[str, str],
+) -> SeriesHandle:
+    """A SeriesHandle pointing at the (cleared) datastore — no instances yet."""
+    study_uid, series_uid = series_uids
+    return SeriesHandle(gcs_client, datastore_path, study_uid, series_uid)
+
+
+@pytest.fixture
+def seeded_series(fresh_series: SeriesHandle, series_files: list[str]) -> SeriesHandle:
+    """fresh_series, plus the two-file fixture ingested via mode='w'."""
+    with fresh_series.open(mode="w") as cod:
+        cod.append([Instance(dicom_uri=p) for p in series_files])
+    return fresh_series

--- a/cloud_optimized_dicom/tests/test_edit.py
+++ b/cloud_optimized_dicom/tests/test_edit.py
@@ -5,85 +5,18 @@ then reopens in mode='r' to verify the edits round-tripped correctly.
 """
 
 import os
-from dataclasses import dataclass
-from typing import Literal
 
 import pydicom3
 import pytest
 from google.cloud import storage
 
-from cloud_optimized_dicom.cod_object import CODObject
 from cloud_optimized_dicom.errors import (
     CODObjectNotFoundError,
     EditSetChangedError,
     LockAcquisitionError,
 )
 from cloud_optimized_dicom.instance import Instance
-
-
-# NOTE: SeriesHandle + the fresh_series/seeded_series fixtures are deliberately
-# local to this test module for now. If a second test file ends up wanting the
-# same boilerplate-collapsing pattern, lift them into conftest.py.
-@dataclass
-class SeriesHandle:
-    """Bundles the four sticky CODObject args so tests can `.open(mode=...)`
-    without re-typing client/datastore_path/study_uid/series_uid every call."""
-
-    client: storage.Client
-    datastore_path: str
-    study_uid: str
-    series_uid: str
-
-    def open(self, mode: Literal["r", "w", "a", "e"], **kwargs) -> CODObject:
-        return CODObject(
-            client=self.client,
-            datastore_path=self.datastore_path,
-            study_uid=self.study_uid,
-            series_uid=self.series_uid,
-            mode=mode,
-            **kwargs,
-        )
-
-
-@pytest.fixture(scope="module")
-def series_dir(test_data_dir: str) -> str:
-    return os.path.join(test_data_dir, "series")
-
-
-@pytest.fixture(scope="module")
-def series_files(series_dir: str) -> list[str]:
-    """First two .dcm files in the series fixture directory."""
-    return sorted(
-        os.path.join(series_dir, f)
-        for f in os.listdir(series_dir)
-        if f.endswith(".dcm")
-    )[:2]
-
-
-@pytest.fixture(scope="module")
-def series_uids(series_files: list[str]) -> tuple[str, str]:
-    """Probe (study_uid, series_uid) from the first series file."""
-    probe = Instance(dicom_uri=series_files[0])
-    return probe.study_uid(), probe.series_uid()
-
-
-@pytest.fixture
-def fresh_series(
-    gcs_client: storage.Client,
-    datastore_path: str,
-    series_uids: tuple[str, str],
-) -> SeriesHandle:
-    """A SeriesHandle pointing at the (cleared) datastore — no instances yet."""
-    study_uid, series_uid = series_uids
-    return SeriesHandle(gcs_client, datastore_path, study_uid, series_uid)
-
-
-@pytest.fixture
-def seeded_series(fresh_series: SeriesHandle, series_files: list[str]) -> SeriesHandle:
-    """fresh_series, plus the two-file fixture ingested via mode='w'."""
-    with fresh_series.open(mode="w") as cod:
-        cod.append([Instance(dicom_uri=p) for p in series_files])
-    return fresh_series
+from cloud_optimized_dicom.tests.conftest import SeriesHandle
 
 
 def test_edit_mode_happy_path(seeded_series: SeriesHandle):

--- a/cloud_optimized_dicom/tests/test_redact.py
+++ b/cloud_optimized_dicom/tests/test_redact.py
@@ -1,0 +1,271 @@
+"""Integration tests for pixel-data redaction via mode='e'.
+
+Each test seeds a series, runs `redact_pixel_data` (via free function or
+`CODObject.redact_pixel_data` method), then reopens in mode='r' to verify
+the pixel data, audit trail, and DICOM tags round-trip as expected.
+"""
+
+import os
+
+import numpy as np
+import pydicom3
+import pytest
+from google.cloud import storage
+
+from cloud_optimized_dicom.bounding_box import BoundingBox
+from cloud_optimized_dicom.errors import (
+    RedactionBoxOutOfBoundsError,
+    RedactionFillValueError,
+    RedactionFrameOutOfRangeError,
+    RedactionTargetMissingError,
+    WriteOperationInReadModeError,
+)
+from cloud_optimized_dicom.instance import Instance
+from cloud_optimized_dicom.redact import redact_pixel_data
+from cloud_optimized_dicom.tests.conftest import SeriesHandle
+
+
+def _read_remote_pixel_array(handle: SeriesHandle, instance_uid: str) -> np.ndarray:
+    """Pull the series tar fresh from GCS, return the pixel_array of the named instance."""
+    with handle.open(mode="r") as cod:
+        cod.extract_locally()
+        instance = cod._get_instance(instance_uid)
+        return pydicom3.dcmread(instance.dicom_uri).pixel_array
+
+
+def _read_remote_dataset(handle: SeriesHandle, instance_uid: str) -> pydicom3.Dataset:
+    with handle.open(mode="r") as cod:
+        cod.extract_locally()
+        instance = cod._get_instance(instance_uid)
+        return pydicom3.dcmread(instance.dicom_uri)
+
+
+@pytest.fixture
+def multiframe_path(test_data_dir: str) -> str:
+    return os.path.join(test_data_dir, "ybr_rct_multiframe.dcm")
+
+
+@pytest.fixture
+def multiframe_seeded_series(
+    gcs_client: storage.Client,
+    datastore_path: str,
+    multiframe_path: str,
+) -> SeriesHandle:
+    """A fresh series ingesting the YBR_RCT JPEG2000Lossless multiframe fixture."""
+    probe = Instance(dicom_uri=multiframe_path)
+    handle = SeriesHandle(
+        gcs_client, datastore_path, probe.study_uid(), probe.series_uid()
+    )
+    with handle.open(mode="w") as cod:
+        cod.append([Instance(dicom_uri=multiframe_path)])
+    return handle
+
+
+def test_redact_single_frame_happy_path(seeded_series: SeriesHandle):
+    """Redacting one box on one instance zeros that region and leaves the
+    rest of the series alone."""
+    with seeded_series.open(mode="r") as cod:
+        uids = list(cod._get_instances(strict_sorting=False).keys())
+    target_uid, untouched_uid = uids[0], uids[1]
+
+    before_target = _read_remote_pixel_array(seeded_series, target_uid)
+    before_untouched = _read_remote_pixel_array(seeded_series, untouched_uid)
+
+    box = BoundingBox(x=10, y=20, width=30, height=40, applies_to=[target_uid])
+
+    with seeded_series.open(mode="e") as cod:
+        cod.redact_pixel_data([box], reviewer="reviewer-a@gradienthealth.io")
+
+    after_target = _read_remote_pixel_array(seeded_series, target_uid)
+    after_untouched = _read_remote_pixel_array(seeded_series, untouched_uid)
+
+    redacted_region = after_target[20:60, 10:40]
+    assert np.all(redacted_region == 0), "redacted region should be zero (MONOCHROME2)"
+
+    # Pixels outside the redaction box must match the original exactly
+    # (JPEG 2000 Lossless round-trip is bit-exact).
+    mask = np.ones_like(after_target, dtype=bool)
+    mask[20:60, 10:40] = False
+    assert np.array_equal(after_target[mask], before_target[mask])
+
+    assert np.array_equal(after_untouched, before_untouched)
+
+
+def test_redact_audit_record_round_trips(seeded_series: SeriesHandle):
+    """The redactions audit list survives sync and accumulates across calls."""
+    with seeded_series.open(mode="r") as cod:
+        uid_a, uid_b = list(cod._get_instances(strict_sorting=False).keys())[:2]
+
+    box_1 = BoundingBox(x=0, y=0, width=10, height=10, applies_to=[uid_a])
+    with seeded_series.open(mode="e") as cod:
+        cod.redact_pixel_data([box_1], reviewer="alice@gradienthealth.io")
+
+    box_2 = BoundingBox(x=5, y=5, width=20, height=20, applies_to=[uid_b])
+    with seeded_series.open(mode="e") as cod:
+        cod.redact_pixel_data([box_2], reviewer="bob@gradienthealth.io")
+
+    with seeded_series.open(mode="r") as cod:
+        records = cod.get_metadata_field("redactions")
+
+    assert isinstance(records, list)
+    assert len(records) == 2
+    assert records[0]["reviewer"] == "alice@gradienthealth.io"
+    assert records[1]["reviewer"] == "bob@gradienthealth.io"
+    assert records[0]["entries"][0]["applies_to"] == [uid_a]
+    assert records[1]["entries"][0]["applies_to"] == [uid_b]
+    assert records[0]["entries"][0]["frames"] is None
+
+
+def test_redact_dicom_tags_stamped(seeded_series: SeriesHandle):
+    """BurnedInAnnotation and DeidentificationMethodCodeSequence are written
+    on every redacted instance."""
+    with seeded_series.open(mode="r") as cod:
+        target_uid = next(iter(cod._get_instances(strict_sorting=False)))
+
+    box = BoundingBox(x=0, y=0, width=5, height=5, applies_to=[target_uid])
+    with seeded_series.open(mode="e") as cod:
+        cod.redact_pixel_data([box], reviewer="reviewer@gradienthealth.io")
+
+    ds = _read_remote_dataset(seeded_series, target_uid)
+    assert str(ds.BurnedInAnnotation) == "NO"
+    seq = ds.DeidentificationMethodCodeSequence
+    assert len(seq) >= 1
+    assert seq[-1].CodeValue == "113101"
+    assert seq[-1].CodingSchemeDesignator == "DCM"
+    assert ds.InstanceCreationDate  # truthy 8-char DA value
+    assert ds.InstanceCreationTime
+
+
+def test_redact_multiframe_specific_frames(multiframe_seeded_series: SeriesHandle):
+    """Redacting only certain frames blacks them and leaves other frames alone."""
+    with multiframe_seeded_series.open(mode="r") as cod:
+        target_uid = next(iter(cod._get_instances(strict_sorting=False)))
+
+    before = _read_remote_pixel_array(multiframe_seeded_series, target_uid)
+    assert before.ndim == 4, "fixture should be (frames, rows, cols, samples)"
+
+    box = BoundingBox(
+        x=100,
+        y=50,
+        width=40,
+        height=30,
+        applies_to=[target_uid],
+        frames=[0, 5],
+    )
+    with multiframe_seeded_series.open(mode="e") as cod:
+        cod.redact_pixel_data([box], reviewer="frame-redactor@gradienthealth.io")
+
+    after = _read_remote_pixel_array(multiframe_seeded_series, target_uid)
+
+    # Redacted frames have zeros in the box region (YBR_RCT: (0,0,0) is black).
+    for f in (0, 5):
+        assert np.all(after[f, 50:80, 100:140, :] == 0), f"frame {f} not zeroed"
+
+    # An unrelated frame is bit-identical to before.
+    assert np.array_equal(after[3], before[3])
+
+
+def test_redact_free_function_opens_edit_mode(seeded_series: SeriesHandle):
+    """The module-level entry point opens mode='e' itself."""
+    with seeded_series.open(mode="r") as cod:
+        target_uid = next(iter(cod._get_instances(strict_sorting=False)))
+
+    box = BoundingBox(x=0, y=0, width=8, height=8, applies_to=[target_uid])
+    redact_pixel_data(
+        client=seeded_series.client,
+        datastore_path=seeded_series.datastore_path,
+        study_uid=seeded_series.study_uid,
+        series_uid=seeded_series.series_uid,
+        boxes=[box],
+        reviewer="entry-point@gradienthealth.io",
+    )
+
+    after = _read_remote_pixel_array(seeded_series, target_uid)
+    assert np.all(after[0:8, 0:8] == 0)
+
+
+def test_redact_missing_uid_raises_and_skips_sync(seeded_series: SeriesHandle):
+    """An applies_to UID not in the series raises and writes nothing."""
+    with seeded_series.open(mode="r") as cod:
+        real_uid = next(iter(cod._get_instances(strict_sorting=False)))
+    before = _read_remote_pixel_array(seeded_series, real_uid)
+
+    bad_box = BoundingBox(x=0, y=0, width=5, height=5, applies_to=["999.999.fake"])
+    with pytest.raises(RedactionTargetMissingError):
+        with seeded_series.open(mode="e") as cod:
+            cod.redact_pixel_data([bad_box], reviewer="r")
+
+    after = _read_remote_pixel_array(seeded_series, real_uid)
+    assert np.array_equal(before, after), "no instance should have been mutated"
+
+    with seeded_series.open(mode="r") as cod:
+        assert cod.get_metadata_field("redactions") is None
+
+
+def test_redact_box_out_of_bounds_raises(seeded_series: SeriesHandle):
+    with seeded_series.open(mode="r") as cod:
+        target_uid = next(iter(cod._get_instances(strict_sorting=False)))
+
+    huge = BoundingBox(x=0, y=0, width=99999, height=99999, applies_to=[target_uid])
+    with pytest.raises(RedactionBoxOutOfBoundsError):
+        with seeded_series.open(mode="e") as cod:
+            cod.redact_pixel_data([huge], reviewer="r")
+
+
+def test_redact_frame_out_of_range_raises(multiframe_seeded_series: SeriesHandle):
+    with multiframe_seeded_series.open(mode="r") as cod:
+        target_uid = next(iter(cod._get_instances(strict_sorting=False)))
+
+    bad = BoundingBox(
+        x=0,
+        y=0,
+        width=5,
+        height=5,
+        applies_to=[target_uid],
+        frames=[9999],
+    )
+    with pytest.raises(RedactionFrameOutOfRangeError):
+        with multiframe_seeded_series.open(mode="e") as cod:
+            cod.redact_pixel_data([bad], reviewer="r")
+
+
+def test_redact_fill_value_type_mismatch_raises(multiframe_seeded_series: SeriesHandle):
+    """SamplesPerPixel=3 (YBR_RCT) needs a 3-tuple fill_value."""
+    with multiframe_seeded_series.open(mode="r") as cod:
+        target_uid = next(iter(cod._get_instances(strict_sorting=False)))
+
+    box = BoundingBox(x=0, y=0, width=5, height=5, applies_to=[target_uid])
+    with pytest.raises(RedactionFillValueError):
+        with multiframe_seeded_series.open(mode="e") as cod:
+            cod.redact_pixel_data([box], reviewer="r", fill_value=0)  # int, not tuple
+
+
+def test_redact_outputs_j2k_lossless_with_stable_sop_uid(
+    seeded_series: SeriesHandle,
+):
+    """Output TS is fixed at JPEG 2000 Lossless and SOPInstanceUID is stable
+    across the redact (regression: pydicom auto-regenerates the SOP UID for
+    lossy compress() calls, which would trip mode='e' set-changed validation;
+    we pass generate_instance_uid=False to suppress that)."""
+    with seeded_series.open(mode="r") as cod:
+        target_uid = next(iter(cod._get_instances(strict_sorting=False)))
+
+    pre = _read_remote_dataset(seeded_series, target_uid)
+    sop_before = pre.SOPInstanceUID
+
+    box = BoundingBox(x=0, y=0, width=10, height=10, applies_to=[target_uid])
+    with seeded_series.open(mode="e") as cod:
+        cod.redact_pixel_data([box], reviewer="ts-test@gradienthealth.io")
+
+    post = _read_remote_dataset(seeded_series, target_uid)
+    assert str(post.file_meta.TransferSyntaxUID) == "1.2.840.10008.1.2.4.90"
+    assert post.SOPInstanceUID == sop_before
+
+
+def test_redact_in_read_mode_raises(seeded_series: SeriesHandle):
+    """The public_method(write_only=True) decorator blocks read-mode calls."""
+    with seeded_series.open(mode="r") as cod:
+        target_uid = next(iter(cod._get_instances(strict_sorting=False)))
+        box = BoundingBox(x=0, y=0, width=5, height=5, applies_to=[target_uid])
+        with pytest.raises(WriteOperationInReadModeError):
+            cod.redact_pixel_data([box], reviewer="r")


### PR DESCRIPTION
Lets reviewers permanently black out PHI regions our de-identification
pipeline misses by handing BoundingBoxes to mode='e'. Affected instances
are decoded, filled, re-encoded as JPEG 2000 Lossless (regardless of
source TS), and stamped with BurnedInAnnotation/DeidentificationMethodCodeSequence.
An audit record (timestamp, reviewer, applied boxes) is appended to the
series-level metadata_fields["redactions"] list. Hard-fails before any
disk write on missing UIDs, out-of-range frames, oversized boxes, or
fill_value mismatches.

Output is normalized to JPEG 2000 Lossless rather than preserving the
source transfer syntax. This sidesteps two pydicom behaviors that would
otherwise corrupt results: lossy compress() regenerates SOPInstanceUID
(tripping mode='e' set-changed validation), and pixel_array auto-converts
the YBR_FULL family to RGB on decode (so the source PhotometricInterpretation
no longer matches the array bytes). Output normalization also matches
what append.py already does on ingest, so in practice nothing's changing
format for data already in COD.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>