### PR TITLE
refactor(PROC-1576): lift SeriesHandle and seeded_series fixtures into conftest

### DIFF
--- a/cloud_optimized_dicom/tests/conftest.py
+++ b/cloud_optimized_dicom/tests/conftest.py
@@ -1,9 +1,13 @@
 import os
+from dataclasses import dataclass
+from typing import Literal
 
 import pytest
 from google.api_core.client_options import ClientOptions
 from google.cloud import storage
 
+from cloud_optimized_dicom.cod_object import CODObject
+from cloud_optimized_dicom.instance import Instance
 from cloud_optimized_dicom.utils import delete_uploaded_blobs
 
 GCP_PROJECT = "gradient-pacs-siskin-172863"
@@ -61,3 +65,65 @@ def test_series_uid() -> str:
 @pytest.fixture(scope="session")
 def test_study_uid() -> str:
     return TEST_STUDY_UID
+
+
+@dataclass
+class SeriesHandle:
+    """Bundles the four sticky CODObject args so tests can `.open(mode=...)`
+    without re-typing client/datastore_path/study_uid/series_uid every call."""
+
+    client: storage.Client
+    datastore_path: str
+    study_uid: str
+    series_uid: str
+
+    def open(self, mode: Literal["r", "w", "a", "e"], **kwargs) -> CODObject:
+        return CODObject(
+            client=self.client,
+            datastore_path=self.datastore_path,
+            study_uid=self.study_uid,
+            series_uid=self.series_uid,
+            mode=mode,
+            **kwargs,
+        )
+
+
+@pytest.fixture(scope="module")
+def series_dir(test_data_dir: str) -> str:
+    return os.path.join(test_data_dir, "series")
+
+
+@pytest.fixture(scope="module")
+def series_files(series_dir: str) -> list[str]:
+    """First two .dcm files in the series fixture directory."""
+    return sorted(
+        os.path.join(series_dir, f)
+        for f in os.listdir(series_dir)
+        if f.endswith(".dcm")
+    )[:2]
+
+
+@pytest.fixture(scope="module")
+def series_uids(series_files: list[str]) -> tuple[str, str]:
+    """Probe (study_uid, series_uid) from the first series file."""
+    probe = Instance(dicom_uri=series_files[0])
+    return probe.study_uid(), probe.series_uid()
+
+
+@pytest.fixture
+def fresh_series(
+    gcs_client: storage.Client,
+    datastore_path: str,
+    series_uids: tuple[str, str],
+) -> SeriesHandle:
+    """A SeriesHandle pointing at the (cleared) datastore — no instances yet."""
+    study_uid, series_uid = series_uids
+    return SeriesHandle(gcs_client, datastore_path, study_uid, series_uid)
+
+
+@pytest.fixture
+def seeded_series(fresh_series: SeriesHandle, series_files: list[str]) -> SeriesHandle:
+    """fresh_series, plus the two-file fixture ingested via mode='w'."""
+    with fresh_series.open(mode="w") as cod:
+        cod.append([Instance(dicom_uri=p) for p in series_files])
+    return fresh_series

--- a/cloud_optimized_dicom/tests/test_edit.py
+++ b/cloud_optimized_dicom/tests/test_edit.py
@@ -5,85 +5,18 @@ then reopens in mode='r' to verify the edits round-tripped correctly.
 """
 
 import os
-from dataclasses import dataclass
-from typing import Literal
 
 import pydicom3
 import pytest
 from google.cloud import storage
 
-from cloud_optimized_dicom.cod_object import CODObject
 from cloud_optimized_dicom.errors import (
     CODObjectNotFoundError,
     EditSetChangedError,
     LockAcquisitionError,
 )
 from cloud_optimized_dicom.instance import Instance
-
-
-# NOTE: SeriesHandle + the fresh_series/seeded_series fixtures are deliberately
-# local to this test module for now. If a second test file ends up wanting the
-# same boilerplate-collapsing pattern, lift them into conftest.py.
-@dataclass
-class SeriesHandle:
-    """Bundles the four sticky CODObject args so tests can `.open(mode=...)`
-    without re-typing client/datastore_path/study_uid/series_uid every call."""
-
-    client: storage.Client
-    datastore_path: str
-    study_uid: str
-    series_uid: str
-
-    def open(self, mode: Literal["r", "w", "a", "e"], **kwargs) -> CODObject:
-        return CODObject(
-            client=self.client,
-            datastore_path=self.datastore_path,
-            study_uid=self.study_uid,
-            series_uid=self.series_uid,
-            mode=mode,
-            **kwargs,
-        )
-
-
-@pytest.fixture(scope="module")
-def series_dir(test_data_dir: str) -> str:
-    return os.path.join(test_data_dir, "series")
-
-
-@pytest.fixture(scope="module")
-def series_files(series_dir: str) -> list[str]:
-    """First two .dcm files in the series fixture directory."""
-    return sorted(
-        os.path.join(series_dir, f)
-        for f in os.listdir(series_dir)
-        if f.endswith(".dcm")
-    )[:2]
-
-
-@pytest.fixture(scope="module")
-def series_uids(series_files: list[str]) -> tuple[str, str]:
-    """Probe (study_uid, series_uid) from the first series file."""
-    probe = Instance(dicom_uri=series_files[0])
-    return probe.study_uid(), probe.series_uid()
-
-
-@pytest.fixture
-def fresh_series(
-    gcs_client: storage.Client,
-    datastore_path: str,
-    series_uids: tuple[str, str],
-) -> SeriesHandle:
-    """A SeriesHandle pointing at the (cleared) datastore — no instances yet."""
-    study_uid, series_uid = series_uids
-    return SeriesHandle(gcs_client, datastore_path, study_uid, series_uid)
-
-
-@pytest.fixture
-def seeded_series(fresh_series: SeriesHandle, series_files: list[str]) -> SeriesHandle:
-    """fresh_series, plus the two-file fixture ingested via mode='w'."""
-    with fresh_series.open(mode="w") as cod:
-        cod.append([Instance(dicom_uri=p) for p in series_files])
-    return fresh_series
+from cloud_optimized_dicom.tests.conftest import SeriesHandle
 
 
 def test_edit_mode_happy_path(seeded_series: SeriesHandle):


### PR DESCRIPTION
Pure test-infra refactor, stacked on #126. The original `test_edit.py` author left a TODO to do this once a second test file needed the same boilerplate; the redaction tests in #125 want the same `SeriesHandle` + `fresh_series` + `seeded_series` setup, so lifting now.

No behavior change. `test_edit.py` imports `SeriesHandle` from conftest and inherits the fixtures.