### PR TITLE
test(PROC-1576): comprehensive coverage for pixel-data redaction

### DIFF
--- a/cloud_optimized_dicom/tests/test_redact.py
+++ b/cloud_optimized_dicom/tests/test_redact.py
@@ -1,18 +1,27 @@
-"""Smoke-level integration tests for pixel-data redaction via mode='e'.
+"""Integration tests for pixel-data redaction via mode='e'.
 
-Covers: redaction works end-to-end, output is normalized to JPEG 2000
-Lossless with a stable SOPInstanceUID, and the API is mode-guarded.
-Comprehensive edge-case coverage (audit trail accumulation, multiframe
-frame-selection, hard-error paths) lives in a follow-up PR stacked on
-top of this one.
+Each test seeds a series, runs `cod.redact_pixel_data(...)`, then reopens in
+mode='r' to verify the pixel data, audit trail, and DICOM tags round-trip
+as expected.
 """
+
+import os
 
 import numpy as np
 import pydicom3
+import pydicom3.examples
 import pytest
+from google.cloud import storage
 
 from cloud_optimized_dicom.bounding_box import BoundingBox, PixelRedaction
-from cloud_optimized_dicom.errors import WriteOperationInReadModeError
+from cloud_optimized_dicom.errors import (
+    RedactionBoxOutOfBoundsError,
+    RedactionFillValueError,
+    RedactionFrameOutOfRangeError,
+    RedactionTargetMissingError,
+    WriteOperationInReadModeError,
+)
+from cloud_optimized_dicom.instance import Instance
 from cloud_optimized_dicom.tests.conftest import SeriesHandle
 
 
@@ -26,6 +35,56 @@ def _read_remote_dataset(handle: SeriesHandle, instance_uid: str) -> pydicom3.Da
 
 def _read_remote_pixel_array(handle: SeriesHandle, instance_uid: str) -> np.ndarray:
     return _read_remote_dataset(handle, instance_uid).pixel_array
+
+
+@pytest.fixture
+def multiframe_path(test_data_dir: str) -> str:
+    return os.path.join(test_data_dir, "ybr_rct_multiframe.dcm")
+
+
+@pytest.fixture
+def multiframe_seeded_series(
+    gcs_client: storage.Client,
+    datastore_path: str,
+    multiframe_path: str,
+) -> SeriesHandle:
+    """A fresh series ingesting the YBR_RCT JPEG2000Lossless multiframe fixture."""
+    probe = Instance(dicom_uri=multiframe_path)
+    handle = SeriesHandle(
+        gcs_client, datastore_path, probe.study_uid(), probe.series_uid()
+    )
+    with handle.open(mode="w") as cod:
+        cod.append([Instance(dicom_uri=multiframe_path)])
+    return handle
+
+
+@pytest.fixture
+def ybr_full_422_path() -> str:
+    """A YBR_FULL_422 JPEG Baseline (lossy) multiframe DICOM. Sourced from
+    pydicom's bundled example set rather than committed to this repo: pydicom
+    documents `examples.ybr_color` as part of the package itself (not the
+    on-demand download set), so it ships with every pydicom install."""
+    return str(pydicom3.examples.get_path("ybr_color"))
+
+
+@pytest.fixture
+def ybr_full_422_seeded_series(
+    gcs_client: storage.Client,
+    datastore_path: str,
+    ybr_full_422_path: str,
+) -> SeriesHandle:
+    """A fresh series ingesting a YBR_FULL_422 JPEG Baseline (lossy) multiframe
+    fixture. instance.compress() in append.py skips re-encoding when the
+    source is already compressed, so the file lands in COD with its original
+    YBR_FULL_422 lossy TS, exercising the auto-convert path that redact.py
+    handles."""
+    probe = Instance(dicom_uri=ybr_full_422_path)
+    handle = SeriesHandle(
+        gcs_client, datastore_path, probe.study_uid(), probe.series_uid()
+    )
+    with handle.open(mode="w") as cod:
+        cod.append([Instance(dicom_uri=ybr_full_422_path)])
+    return handle
 
 
 def test_redact_single_frame_happy_path(seeded_series: SeriesHandle):
@@ -59,6 +118,191 @@ def test_redact_single_frame_happy_path(seeded_series: SeriesHandle):
     assert np.array_equal(after_target[mask], before_target[mask])
 
     assert np.array_equal(after_untouched, before_untouched)
+
+
+def test_redact_audit_record_round_trips(seeded_series: SeriesHandle):
+    """The redactions audit list survives sync and accumulates across calls."""
+    with seeded_series.open(mode="r") as cod:
+        uid_a, uid_b = list(cod._get_instances(strict_sorting=False).keys())[:2]
+
+    redaction_1 = PixelRedaction(
+        box=BoundingBox(x=0, y=0, width=10, height=10), applies_to=[uid_a]
+    )
+    with seeded_series.open(mode="e") as cod:
+        cod.redact_pixel_data([redaction_1], reviewer="alice@gradienthealth.io")
+
+    redaction_2 = PixelRedaction(
+        box=BoundingBox(x=5, y=5, width=20, height=20), applies_to=[uid_b]
+    )
+    with seeded_series.open(mode="e") as cod:
+        cod.redact_pixel_data([redaction_2], reviewer="bob@gradienthealth.io")
+
+    with seeded_series.open(mode="r") as cod:
+        records = cod.get_metadata_field("redactions")
+
+    assert isinstance(records, list)
+    assert len(records) == 2
+    assert records[0]["reviewer"] == "alice@gradienthealth.io"
+    assert records[1]["reviewer"] == "bob@gradienthealth.io"
+    assert records[0]["entries"][0]["applies_to"] == [uid_a]
+    assert records[1]["entries"][0]["applies_to"] == [uid_b]
+    assert records[0]["entries"][0]["frames"] is None
+    assert records[0]["entries"][0]["box"] == {
+        "x": 0,
+        "y": 0,
+        "width": 10,
+        "height": 10,
+    }
+
+
+def test_redact_dicom_tags_stamped(seeded_series: SeriesHandle):
+    """BurnedInAnnotation and DeidentificationMethodCodeSequence are written
+    on every redacted instance, and original creation timestamps are preserved
+    (those describe acquisition/reconstruction time, not "when the redactor
+    last touched it")."""
+    with seeded_series.open(mode="r") as cod:
+        target_uid = next(iter(cod._get_instances(strict_sorting=False)))
+
+    pre = _read_remote_dataset(seeded_series, target_uid)
+    creation_date_before = getattr(pre, "InstanceCreationDate", None)
+    creation_time_before = getattr(pre, "InstanceCreationTime", None)
+
+    redaction = PixelRedaction(
+        box=BoundingBox(x=0, y=0, width=5, height=5), applies_to=[target_uid]
+    )
+    with seeded_series.open(mode="e") as cod:
+        cod.redact_pixel_data([redaction], reviewer="reviewer@gradienthealth.io")
+
+    ds = _read_remote_dataset(seeded_series, target_uid)
+    assert str(ds.BurnedInAnnotation) == "NO"
+    seq = ds.DeidentificationMethodCodeSequence
+    assert len(seq) >= 1
+    assert seq[-1].CodeValue == "113101"
+    assert seq[-1].CodingSchemeDesignator == "DCM"
+    assert getattr(ds, "InstanceCreationDate", None) == creation_date_before
+    assert getattr(ds, "InstanceCreationTime", None) == creation_time_before
+
+
+def test_redact_multiframe_specific_frames(multiframe_seeded_series: SeriesHandle):
+    """Redacting only certain frames blacks them and leaves other frames alone."""
+    with multiframe_seeded_series.open(mode="r") as cod:
+        target_uid = next(iter(cod._get_instances(strict_sorting=False)))
+
+    before = _read_remote_pixel_array(multiframe_seeded_series, target_uid)
+    assert before.ndim == 4, "fixture should be (frames, rows, cols, samples)"
+
+    redaction = PixelRedaction(
+        box=BoundingBox(x=100, y=50, width=40, height=30),
+        applies_to=[target_uid],
+        frames=[0, 5],
+    )
+    with multiframe_seeded_series.open(mode="e") as cod:
+        cod.redact_pixel_data([redaction], reviewer="frame-redactor@gradienthealth.io")
+
+    after = _read_remote_pixel_array(multiframe_seeded_series, target_uid)
+
+    # Redacted frames have zeros in the box region (YBR_RCT: (0,0,0) is black).
+    for f in (0, 5):
+        assert np.all(after[f, 50:80, 100:140, :] == 0), f"frame {f} not zeroed"
+
+    # An unrelated frame is bit-identical to before.
+    assert np.array_equal(after[3], before[3])
+
+
+def test_redact_ybr_full_422_rewrites_photometric_to_rgb(
+    ybr_full_422_seeded_series: SeriesHandle,
+):
+    """A YBR_FULL_422 lossy source comes out as RGB JPEG 2000 Lossless.
+
+    pydicom's pixel_array auto-converts the YBR_FULL family to RGB on decode,
+    so by the time we re-encode the array IS RGB; redact.py rewrites
+    PhotometricInterpretation accordingly so the header matches the bytes.
+    Without that rewrite, the file would have RGB pixel data tagged as YBR.
+    """
+    with ybr_full_422_seeded_series.open(mode="r") as cod:
+        target_uid = next(iter(cod._get_instances(strict_sorting=False)))
+
+    pre = _read_remote_dataset(ybr_full_422_seeded_series, target_uid)
+    assert pre.PhotometricInterpretation == "YBR_FULL_422"
+    assert not str(pre.file_meta.TransferSyntaxUID).startswith(
+        "1.2.840.10008.1.2.4.90"
+    ), "fixture should land in COD with its original lossy TS"
+    sop_before = pre.SOPInstanceUID
+
+    redaction = PixelRedaction(
+        box=BoundingBox(x=10, y=10, width=20, height=20),
+        applies_to=[target_uid],
+        frames=[0],
+    )
+    with ybr_full_422_seeded_series.open(mode="e") as cod:
+        cod.redact_pixel_data([redaction], reviewer="ybr-test@gradienthealth.io")
+
+    post = _read_remote_dataset(ybr_full_422_seeded_series, target_uid)
+    assert post.PhotometricInterpretation == "RGB"
+    assert str(post.file_meta.TransferSyntaxUID) == "1.2.840.10008.1.2.4.90"
+    assert post.SOPInstanceUID == sop_before
+    assert np.all(post.pixel_array[0, 10:30, 10:30, :] == 0)
+
+
+def test_redact_missing_uid_raises_and_skips_sync(seeded_series: SeriesHandle):
+    """An applies_to UID not in the series raises and writes nothing."""
+    with seeded_series.open(mode="r") as cod:
+        real_uid = next(iter(cod._get_instances(strict_sorting=False)))
+    before = _read_remote_pixel_array(seeded_series, real_uid)
+
+    bad = PixelRedaction(
+        box=BoundingBox(x=0, y=0, width=5, height=5), applies_to=["999.999.fake"]
+    )
+    with pytest.raises(RedactionTargetMissingError):
+        with seeded_series.open(mode="e") as cod:
+            cod.redact_pixel_data([bad], reviewer="r")
+
+    after = _read_remote_pixel_array(seeded_series, real_uid)
+    assert np.array_equal(before, after), "no instance should have been mutated"
+
+    with seeded_series.open(mode="r") as cod:
+        assert cod.get_metadata_field("redactions") is None
+
+
+def test_redact_box_out_of_bounds_raises(seeded_series: SeriesHandle):
+    with seeded_series.open(mode="r") as cod:
+        target_uid = next(iter(cod._get_instances(strict_sorting=False)))
+
+    huge = PixelRedaction(
+        box=BoundingBox(x=0, y=0, width=99999, height=99999), applies_to=[target_uid]
+    )
+    with pytest.raises(RedactionBoxOutOfBoundsError):
+        with seeded_series.open(mode="e") as cod:
+            cod.redact_pixel_data([huge], reviewer="r")
+
+
+def test_redact_frame_out_of_range_raises(multiframe_seeded_series: SeriesHandle):
+    with multiframe_seeded_series.open(mode="r") as cod:
+        target_uid = next(iter(cod._get_instances(strict_sorting=False)))
+
+    bad = PixelRedaction(
+        box=BoundingBox(x=0, y=0, width=5, height=5),
+        applies_to=[target_uid],
+        frames=[9999],
+    )
+    with pytest.raises(RedactionFrameOutOfRangeError):
+        with multiframe_seeded_series.open(mode="e") as cod:
+            cod.redact_pixel_data([bad], reviewer="r")
+
+
+def test_redact_fill_value_type_mismatch_raises(multiframe_seeded_series: SeriesHandle):
+    """SamplesPerPixel=3 (YBR_RCT) needs a 3-tuple fill_value."""
+    with multiframe_seeded_series.open(mode="r") as cod:
+        target_uid = next(iter(cod._get_instances(strict_sorting=False)))
+
+    redaction = PixelRedaction(
+        box=BoundingBox(x=0, y=0, width=5, height=5), applies_to=[target_uid]
+    )
+    with pytest.raises(RedactionFillValueError):
+        with multiframe_seeded_series.open(mode="e") as cod:
+            cod.redact_pixel_data(
+                [redaction], reviewer="r", fill_value=0  # int, not tuple
+            )
 
 
 def test_redact_outputs_j2k_lossless_with_stable_sop_uid(

--- a/getting_started.ipynb
+++ b/getting_started.ipynb
@@ -361,6 +361,52 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Redact PHI from pixel data with `redact_pixel_data`\n",
+    "\n",
+    "When a reviewer spots PHI burned into the pixels (e.g., a patient name overlay) that the upstream de-identification pipeline missed, `redact_pixel_data` blacks out rectangular regions on specified instances and frames. It's a thin wrapper over `mode=\"e\"` that handles decoding, filling, re-encoding to JPEG 2000 Lossless, stamping the standard de-id DICOM tags (`BurnedInAnnotation = \"NO\"`, `DeidentificationMethodCodeSequence`), and appending an audit record to series-level metadata."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from cloud_optimized_dicom.bounding_box import BoundingBox, PixelRedaction\n",
+    "\n",
+    "# Black out a 200x200 rectangle near the center of instance_a (image is 614x816).\n",
+    "redaction = PixelRedaction(\n",
+    "    box=BoundingBox(x=300, y=200, width=200, height=200),\n",
+    "    applies_to=[instance_a.instance_uid()],\n",
+    ")\n",
+    "\n",
+    "with CODObject(datastore_path=datastore_path,\n",
+    "               client=client,\n",
+    "               study_uid=instance_a.study_uid(),\n",
+    "               series_uid=instance_a.series_uid(),\n",
+    "               mode=\"e\") as cod_obj:\n",
+    "    cod_obj.redact_pixel_data([redaction], reviewer=\"reviewer@gradienthealth.io\")\n",
+    "\n",
+    "# Verify the region is zeroed and the audit record landed in series metadata.\n",
+    "with CODObject(datastore_path=datastore_path,\n",
+    "               client=client,\n",
+    "               study_uid=instance_a.study_uid(),\n",
+    "               series_uid=instance_a.series_uid(),\n",
+    "               mode=\"r\") as cod_obj:\n",
+    "    cod_obj.extract_locally()\n",
+    "    inst = cod_obj.get_instance(instance_a.instance_uid())\n",
+    "    arr = pydicom.dcmread(inst.dicom_uri).pixel_array\n",
+    "    print(f\"Redacted region all zero: {(arr[200:400, 300:500] == 0).all()}\")\n",
+    "\n",
+    "    audit = cod_obj.get_metadata_field(\"redactions\")\n",
+    "    print(f\"Audit records on series: {len(audit)}\")\n",
+    "    print(f\"Most recent reviewer: {audit[-1]['reviewer']}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Interact with COD datastore via DICOMweb requests"
    ]
   },


### PR DESCRIPTION
Stacked on #125. Adds the edge-case integration tests that the smoke layer in #125 doesn't exercise.

- Audit record round-trips and accumulates across multiple `redact_pixel_data` calls.
- DICOM provenance tags (`BurnedInAnnotation`, `DeidentificationMethodCodeSequence`, `InstanceCreationDate`/`Time`) stamped correctly.
- Multiframe frame-selective redaction: only listed frames are zeroed, other frames are bit-identical to before.
- Each hard-error path (missing UID, oversized box, frame out of range, `fill_value` type mismatch) raises and writes nothing.

New fixtures: `multiframe_path` and `multiframe_seeded_series` for the `ybr_rct_multiframe.dcm` test data.