### PR TITLE
feat(PROC-1668)!: drop pydicom3 fork in favor of upstream pydicom

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,10 +15,6 @@ updates:
     commit-message:
       prefix: chore
       include: scope
-    ignore:
-      # pydicom is pinned at 2.3.0 to validate output from the pydicom3 fork;
-      # bumping it would silently break that validation.
-      - dependency-name: pydicom
     groups:
       python-dependencies:
         update-types:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,7 +146,7 @@ cloud_optimized_dicom/
 ### Dependencies
 
 **Core:**
-- `pydicom3`: Custom fork with namespace isolation (published package)
+- `pydicom>=3.0`: Upstream pydicom 3
 - `google-cloud-storage`: GCS operations
 - `ratarmountcore`: Efficient tar file access
 - `zstandard`: Metadata compression (v2.0)
@@ -156,7 +156,6 @@ cloud_optimized_dicom/
 - `apache-beam[gcp]`: Data processing; install with `pip install cloud-optimized-dicom[beam]`. Without Beam, metric counters silently no-op.
 
 **Test:**
-- `pydicom==2.3.0`: Original pydicom for validation
 - `matplotlib`: Visualization in tests
 
 ### Important Patterns
@@ -189,7 +188,7 @@ with CODObject(client=..., datastore_path=..., mode="a") as cod:
 with CODObject(client=..., datastore_path=..., mode="e") as cod:
     for instance in cod.get_instances().values():
         # instance.dicom_uri now points at a local .dcm the caller can rewrite
-        ds = pydicom3.dcmread(instance.dicom_uri)
+        ds = pydicom.dcmread(instance.dicom_uri)
         ds.PatientName = "REDACTED"
         ds.save_as(instance.dicom_uri)
 # sync() called automatically: tar repacked, metadata rebuilt, thumbnail regenerated if pixel data changed

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ SISKIN_ENV_ENABLED=1 python -m unittest discover -v cloud_optimized_dicom.tests
 ## Project Structure
 
 The project uses `pyproject.toml` for package configuration and dependency management. Key dependencies include:
-- `pydicom3`: Custom fork of pydicom with namespace isolation
+- `pydicom`: DICOM parser/writer (upstream pydicom 3)
 - `google-cloud-storage`: For cloud storage operations
 - `zstandard`: For metadata compression (v2.0)
 - `apache-beam[gcp]` (optional): For data processing pipelines — install with `pip install cloud-optimized-dicom[beam]`

--- a/cloud_optimized_dicom/config.py
+++ b/cloud_optimized_dicom/config.py
@@ -1,6 +1,6 @@
 import logging
 
-import pydicom3
+import pydicom
 
 logger = logging.getLogger("cloud_optimized_dicom")
 logger.addHandler(logging.NullHandler())
@@ -46,8 +46,21 @@ def get_child_logger(name: str):
 # by default, we leave the NullHandler in place and set logging to WARNING
 debug(False, False)
 
-# To maximize compatibility we set pydicom3.config.convert_wrong_length_to_UN = True by default
+# To maximize compatibility we set pydicom.config.convert_wrong_length_to_UN = True by default
 # Pydicom's default behavior (False) is to raise an error when attempting to read a DICOM file with a weird/bad private tag
 # The design philosophy of COD is to "ingest everything we can", which includes such technically invalid DICOM files
-# If a user wants to be more strict, they can set pydicom3.config.convert_wrong_length_to_UN = False
-pydicom3.config.convert_wrong_length_to_UN = True
+# If a user wants to be more strict, they can set pydicom.config.convert_wrong_length_to_UN = False
+pydicom.config.convert_wrong_length_to_UN = True
+
+
+# Suppress per-plugin tracebacks from pydicom.pixels.decoders.base._decode_frame: when every plugin
+# fails the loop re-raises a RuntimeError summarizing each failure, so the LOGGER.exception(exc)
+# emitted on each attempt is duplicate noise (replaces the carried fork patch).
+class _DecodeFrameExceptionFilter(logging.Filter):
+    def filter(self, record: logging.LogRecord) -> bool:
+        return record.funcName != "_decode_frame"
+
+
+logging.getLogger("pydicom.pixels.decoders.base").addFilter(
+    _DecodeFrameExceptionFilter()
+)

--- a/cloud_optimized_dicom/custom_offset_tables.py
+++ b/cloud_optimized_dicom/custom_offset_tables.py
@@ -1,9 +1,9 @@
 from typing import Generator, Tuple
 
-import pydicom3
-import pydicom3.errors
-import pydicom3.filebase
-import pydicom3.tag
+import pydicom
+import pydicom.errors
+import pydicom.filebase
+import pydicom.tag
 
 from cloud_optimized_dicom.config import logger
 
@@ -13,7 +13,7 @@ BOT_PER_ELEMENT_SIZE = 4
 
 
 def _generate_pixel_data_fragment_extended(
-    fp: pydicom3.filebase.DicomFileLike,
+    fp: pydicom.filebase.DicomFileLike,
 ) -> Generator[Tuple[bytes, int], None, None]:
     """
     Based on PyDICOM generate_pixel_data_fragment
@@ -43,7 +43,7 @@ def _generate_pixel_data_fragment_extended(
     # fragment after the Basic Offset Table
     while True:
         try:
-            tag = pydicom3.tag.Tag(fp.read_tag())
+            tag = pydicom.tag.Tag(fp.read_tag())
         except EOFError:
             break
 
@@ -90,7 +90,7 @@ def _get_offsets_for_encapsulated_pixeldata(
         It uses the `_generate_pixel_data_fragment_extended` function to iterate over the
         fragments of the pixel data and calculates the offsets and file positions accordingly.
     """
-    dicom_bytes_io = pydicom3.filebase.DicomBytesIO(pixel_data)
+    dicom_bytes_io = pydicom.filebase.DicomBytesIO(pixel_data)
     dicom_bytes_io.is_little_endian = True
 
     fragment_count = 0
@@ -157,7 +157,7 @@ def _get_offsets_for_encapsulated_pixeldata(
 
 def _get_offsets_for_uncompressed_pixeldata(
     pixel_data_offset: int,
-    pixel_data_element: pydicom3.DataElement,
+    pixel_data_element: pydicom.DataElement,
     num_of_frames: int,
 ) -> Generator[Tuple[int, int, int], None, None]:
     """
@@ -186,7 +186,7 @@ def _get_offsets_for_uncompressed_pixeldata(
 
 
 def _generate_pixel_data_fragment_offsets(
-    dataset: pydicom3.Dataset,
+    dataset: pydicom.Dataset,
 ) -> Generator[Tuple[int, int, int], None, None]:
     """
     DICOM Standard :
@@ -224,7 +224,7 @@ def _generate_pixel_data_fragment_offsets(
     pixel_data_offset = pixel_data_element.file_tell
 
     if not pixel_data_offset:
-        raise pydicom3.errors.InvalidDicomError("Pixel data not found in the DICOM")
+        raise pydicom.errors.InvalidDicomError("Pixel data not found in the DICOM")
 
     if not pixel_data_element.is_undefined_length:
         num_of_frames = int(dataset["NumberOfFrames"].value)
@@ -240,7 +240,7 @@ def _generate_pixel_data_fragment_offsets(
         )
 
 
-def get_multiframe_offset_tables(dataset: pydicom3.Dataset) -> dict:
+def get_multiframe_offset_tables(dataset: pydicom.Dataset) -> dict:
     """
     Get offset tables for multiframe datasets.
 
@@ -283,7 +283,7 @@ def get_multiframe_offset_tables(dataset: pydicom3.Dataset) -> dict:
 
     except (EOFError, ValueError):
         logger.warning("Some errors occured when creating Offset table")
-    except pydicom3.errors.InvalidDicomError as error:
+    except pydicom.errors.InvalidDicomError as error:
         logger.warning(str(error))
 
     return result

--- a/cloud_optimized_dicom/dicomweb.py
+++ b/cloud_optimized_dicom/dicomweb.py
@@ -4,7 +4,7 @@ import re
 from tempfile import NamedTemporaryFile
 from typing import Iterator, Optional
 
-import pydicom3.encaps
+import pydicom.encaps
 from google.cloud import storage
 
 from cloud_optimized_dicom.cod_object import CODObject
@@ -161,10 +161,10 @@ class DicomwebRequest:
             tar_blob.download_to_filename(
                 temp_file.name, start=start_byte, end=end_byte
             )
-            with pydicom3.dcmread(temp_file.name) as ds:
+            with pydicom.dcmread(temp_file.name) as ds:
                 # TODO: this returns raw frame bytes... do we want to support transcoding to jpg?
                 frames = [
-                    pydicom3.encaps.get_frame(buffer=ds.PixelData, index=frame_index)
+                    pydicom.encaps.get_frame(buffer=ds.PixelData, index=frame_index)
                     for frame_index in frame_indices
                 ]
         return frames

--- a/cloud_optimized_dicom/instance.py
+++ b/cloud_optimized_dicom/instance.py
@@ -5,9 +5,9 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Callable, Optional
 
-import pydicom3
-import pydicom3.uid
-from pydicom3.datadict import tag_for_keyword
+import pydicom
+import pydicom.uid
+from pydicom.datadict import tag_for_keyword
 from ratarmountcore.mountsource.factory import open_mount_source as rmc_open
 from smart_open import open as smart_open
 
@@ -141,7 +141,7 @@ class Instance:
         with self.open() as f:
             # defer loading all tags (every tag is > 1 byte) bc we only need UIDs and pixeldata existence
             # stop_before_pixels=True cannot be used here bc it prevents us from checking for pixeldata existence
-            with pydicom3.dcmread(f, defer_size=1) as ds:
+            with pydicom.dcmread(f, defer_size=1) as ds:
                 self._instance_uid = getattr(ds, "SOPInstanceUID")
                 self._series_uid = getattr(ds, "SeriesInstanceUID")
                 self._study_uid = getattr(ds, "StudyInstanceUID")
@@ -316,11 +316,11 @@ class Instance:
         start, stop = self._byte_offsets[0], self._byte_offsets[1] + 1
         return VirtualFile(master_file_pointer, start, stop)
 
-    def compress(self, syntax: pydicom3.uid.UID = pydicom3.uid.JPEG2000Lossless):
+    def compress(self, syntax: pydicom.uid.UID = pydicom.uid.JPEG2000Lossless):
         """Compress the instance to the given syntax. Fails if used prior to fetching, or if the local instance is nested in a tar.
 
         Args:
-            syntax: pydicom3.uid.UID to transcode to. Defaults to JPEG2000Lossless.
+            syntax: pydicom.uid.UID to transcode to. Defaults to JPEG2000Lossless.
         """
         if self.is_nested_in_tar or is_remote(self.dicom_uri):
             raise ValueError(
@@ -333,11 +333,13 @@ class Instance:
         # open the original instance
         with self.open() as f:
             # read the instance
-            with pydicom3.dcmread(f, defer_size=1024) as ds:
+            with pydicom.dcmread(f, defer_size=1024) as ds:
                 if ds.file_meta.TransferSyntaxUID.is_compressed:
                     logger.info(f"Skipping transcode ({self} is already compressed)")
                     return
-                ds.compress(syntax)
+                # generate_instance_uid=False keeps the SOPInstanceUID stable across the transcode;
+                # COD identifies instances by UID, so a regenerated UID would orphan the entry.
+                ds.compress(syntax, generate_instance_uid=False)
                 # make a new temp file to write the transcoded instance to
                 with tempfile.NamedTemporaryFile(
                     suffix=".dcm", delete=False
@@ -417,12 +419,12 @@ class Instance:
         if output_uri is None:
             output_uri = self.dicom_uri
         with self.open() as f:
-            with pydicom3.dcmread(f, defer_size=1024) as ds:
+            with pydicom.dcmread(f, defer_size=1024) as ds:
                 # set custom offset tables
                 self._custom_offset_tables = get_multiframe_offset_tables(ds)
 
                 # define custom bulk data handler to include the head 512 bytes of overlarge elements
-                def bulk_data_handler(el: pydicom3.DataElement) -> str:
+                def bulk_data_handler(el: pydicom.DataElement) -> str:
                     """Given a bulk data element, return a dict containing this instance's output_uri
                     and the head 512 bytes of the element"""
                     # TODO would be nice to find a way to include the tail 512 bytes as well
@@ -466,7 +468,7 @@ class Instance:
         """Compute the crc32c hash of just the pixeldata"""
         with tempfile.NamedTemporaryFile(suffix="_pixeldata") as temp_file:
             with self.open() as ptr:
-                ds = pydicom3.dcmread(ptr, defer_size=1024)
+                ds = pydicom.dcmread(ptr, defer_size=1024)
                 # write ds.pixelData to temp_file
                 temp_file.write(ds.PixelData)
                 temp_file.flush()

--- a/cloud_optimized_dicom/redact.py
+++ b/cloud_optimized_dicom/redact.py
@@ -21,8 +21,8 @@ from collections import defaultdict
 from typing import TYPE_CHECKING, Optional, Union
 
 import numpy as np
-import pydicom3
-from pydicom3.uid import JPEG2000Lossless
+import pydicom
+from pydicom.uid import JPEG2000Lossless
 
 from cloud_optimized_dicom.bounding_box import PixelRedaction
 from cloud_optimized_dicom.errors import (
@@ -77,9 +77,9 @@ def redact_pixel_data(
     # in-memory footprint at header-only until the apply step calls
     # ds.pixel_array, which avoids holding all instances' decoded pixel
     # data simultaneously when N is large.
-    datasets: dict[str, pydicom3.Dataset] = {}
+    datasets: dict[str, pydicom.Dataset] = {}
     for uid, uid_redactions in redactions_by_uid.items():
-        ds = pydicom3.dcmread(instances[uid].dicom_uri, defer_size=1024)
+        ds = pydicom.dcmread(instances[uid].dicom_uri, defer_size=1024)
         _validate_redactions_against_header(uid, ds, uid_redactions, fill_value)
         datasets[uid] = ds
 
@@ -115,7 +115,7 @@ def _group_by_uid(
 
 def _validate_redactions_against_header(
     uid: str,
-    ds: pydicom3.Dataset,
+    ds: pydicom.Dataset,
     redactions: list[PixelRedaction],
     fill_value: Optional[FillValue],
 ) -> None:
@@ -184,7 +184,7 @@ def _derive_fill_value(samples: int, pi: str, bits_stored: int) -> FillValue:
 
 def _apply_to_instance(
     instance: "Instance",
-    ds: pydicom3.Dataset,
+    ds: pydicom.Dataset,
     redactions: list[PixelRedaction],
     fill_value: Optional[FillValue],
 ) -> None:
@@ -226,9 +226,9 @@ def _apply_to_instance(
     _stamp_deid_tags(ds)
 
     # Always normalize to JPEG 2000 Lossless (see module docstring for why).
-    # Lossless leaves SOPInstanceUID alone, which mode='e' set-changed validation
-    # relies on; pydicom only auto-regenerates the UID for lossy compresses.
-    ds.compress(JPEG2000Lossless, arr=arr)
+    # generate_instance_uid=False keeps the SOPInstanceUID stable, which mode='e'
+    # set-changed validation relies on.
+    ds.compress(JPEG2000Lossless, arr=arr, generate_instance_uid=False)
 
     # Write to a sibling temp file then atomically rename. pydicom's save_as
     # truncates the destination before iterating tags to write; if the
@@ -243,7 +243,7 @@ def _apply_to_instance(
     os.replace(tmp, target)
 
 
-def _stamp_deid_tags(ds: pydicom3.Dataset) -> None:
+def _stamp_deid_tags(ds: pydicom.Dataset) -> None:
     """Mark the instance as having had its pixel data scrubbed of PHI.
 
     Two standard tags get touched. Each one is what downstream consumers
@@ -269,7 +269,7 @@ def _stamp_deid_tags(ds: pydicom3.Dataset) -> None:
     # did. Required to claim Basic Confidentiality Profile compliance.
     # Append rather than overwrite: upstream text/metadata de-id may have
     # already added entries we mustn't clobber.
-    method_item = pydicom3.Dataset()
+    method_item = pydicom.Dataset()
     method_item.CodeValue = _DEID_METHOD_CODE
     method_item.CodingSchemeDesignator = _DEID_METHOD_DESIGNATOR
     method_item.CodeMeaning = _DEID_METHOD_MEANING

--- a/cloud_optimized_dicom/tests/test_appender.py
+++ b/cloud_optimized_dicom/tests/test_appender.py
@@ -1,7 +1,7 @@
 import os
 from tempfile import NamedTemporaryFile
 
-import pydicom3
+import pydicom
 import pytest
 from google.cloud import storage
 
@@ -174,7 +174,7 @@ def test_append_diff_hash_dupe(
     )
     # make a diff hash dupe
     with NamedTemporaryFile(suffix=".dcm") as f:
-        with pydicom3.dcmread(local_instance_path) as ds:
+        with pydicom.dcmread(local_instance_path) as ds:
             ds.add_new((0x1234, 0x5678), "DS", "12345678")
             ds.save_as(f.name)
         assert os.path.exists(f.name)
@@ -382,7 +382,7 @@ def test_append_corrupt_dicom(
 
     # create a corrupt dicom (has proper header but then is garbage)
     with NamedTemporaryFile(suffix=".dcm") as f:
-        with pydicom3.FileDataset(
+        with pydicom.FileDataset(
             f.name, {}, is_little_endian=True, is_implicit_VR=False
         ) as ds:
             ds.StudyInstanceUID = (
@@ -465,14 +465,14 @@ def test_append_compress(
     )
     instance = Instance(dicom_uri=local_instance_path)
     with instance.open() as f:
-        ds = pydicom3.dcmread(f)
-        assert ds.file_meta.TransferSyntaxUID == pydicom3.uid.ImplicitVRLittleEndian
+        ds = pydicom.dcmread(f)
+        assert ds.file_meta.TransferSyntaxUID == pydicom.uid.ImplicitVRLittleEndian
     uncompressed_size = instance.size()
     new, same, conflict, errors = cod_obj.append([instance], compress=True)
     assert len(new) == 1
     assert len(same + conflict + errors) == 0
     assert instance.size() < uncompressed_size
     with instance.open() as f:
-        ds = pydicom3.dcmread(f)
-        assert ds.file_meta.TransferSyntaxUID == pydicom3.uid.JPEG2000Lossless
+        ds = pydicom.dcmread(f)
+        assert ds.file_meta.TransferSyntaxUID == pydicom.uid.JPEG2000Lossless
     assert instance.size() < uncompressed_size

--- a/cloud_optimized_dicom/tests/test_cod_object.py
+++ b/cloud_optimized_dicom/tests/test_cod_object.py
@@ -1,6 +1,6 @@
 import pytest
 from google.cloud import storage
-from pydicom3 import dcmread
+from pydicom import dcmread
 
 from cloud_optimized_dicom.cod_object import CODObject
 from cloud_optimized_dicom.instance import Instance

--- a/cloud_optimized_dicom/tests/test_concat.py
+++ b/cloud_optimized_dicom/tests/test_concat.py
@@ -4,8 +4,8 @@ import os
 import tempfile
 from dataclasses import dataclass
 
-import pydicom3
-import pydicom3.tag
+import pydicom
+import pydicom.tag
 import pytest
 from google.cloud import storage
 from google.cloud.storage.retry import DEFAULT_RETRY
@@ -192,7 +192,7 @@ def test_pipeline_and_check_offsets(
                 assert instance._byte_offsets is not None
                 tar.seek(instance._byte_offsets[0])
                 data = tar.read(instance._byte_offsets[1] - instance._byte_offsets[0])
-                with pydicom3.dcmread(io.BytesIO(data)) as ds:
+                with pydicom.dcmread(io.BytesIO(data)) as ds:
                     assert ds.SOPInstanceUID == instance.instance_uid()
 
 
@@ -306,11 +306,11 @@ def test_diff_hash(
     v2_blob = storage.Blob.from_string(v2_uri, client=gcs_client)
     v1_blob.upload_from_filename(dcm_path)
     # change something (cause hash mismatch)
-    ds = pydicom3.dcmread(dcm_path)
+    ds = pydicom.dcmread(dcm_path)
     study_uid = getattr(ds, "StudyInstanceUID")
     series_uid = getattr(ds, "SeriesInstanceUID")
     instance_uid = getattr(ds, "SOPInstanceUID")
-    ds.add_new(pydicom3.tag.Tag(0x6001, 0x0010), "LO", "Gradient Health")
+    ds.add_new(pydicom.tag.Tag(0x6001, 0x0010), "LO", "Gradient Health")
     with tempfile.NamedTemporaryFile() as temp_file:
         ds.save_as(temp_file.name)
         v2_blob.upload_from_filename(temp_file.name)
@@ -379,7 +379,7 @@ def test_diff_hash_pixeldata(
     v2_blob = storage.Blob.from_string(v2_uri, client=gcs_client)
     v1_blob.upload_from_filename(dcm_path, retry=DEFAULT_RETRY)
     # load ds & cause hash mismatch in pixel data
-    ds = pydicom3.dcmread(dcm_path)
+    ds = pydicom.dcmread(dcm_path)
     study_uid = getattr(ds, "StudyInstanceUID")
     series_uid = getattr(ds, "SeriesInstanceUID")
     getattr(ds, "SOPInstanceUID")

--- a/cloud_optimized_dicom/tests/test_custom_offset_tables.py
+++ b/cloud_optimized_dicom/tests/test_custom_offset_tables.py
@@ -2,9 +2,9 @@ import random
 from io import BytesIO
 
 import numpy as np
-import pydicom3
-import pydicom3.encaps
-import pydicom3.errors
+import pydicom
+import pydicom.encaps
+import pydicom.errors
 from pytest_mock import MockerFixture
 
 from cloud_optimized_dicom.custom_offset_tables import get_multiframe_offset_tables
@@ -29,7 +29,7 @@ def create_sample_dataset(
     is_pixeldata_encapsulated=True,
     include_eot=False,
     include_bot=False,
-) -> pydicom3.Dataset:
+) -> pydicom.Dataset:
     """
     Creates a sample DICOM dataset.
 
@@ -42,12 +42,12 @@ def create_sample_dataset(
     Returns:
         pydicom.Dataset: A sample DICOM dataset created using the given parameters.
     """
-    file_meta = pydicom3.FileMetaDataset()
+    file_meta = pydicom.FileMetaDataset()
     file_meta.MediaStorageSOPClassUID = _generate_uid()
     file_meta.MediaStorageSOPInstanceUID = _generate_uid()
     file_meta.TransferSyntaxUID = _generate_uid()
 
-    ds = pydicom3.Dataset()
+    ds = pydicom.Dataset()
     ds.file_meta = file_meta
 
     ds.PatientName = "Test^Patient"
@@ -60,7 +60,7 @@ def create_sample_dataset(
     raw_pixeldata = [_generate_random_pixel_data(200) for _ in range(number_of_frames)]
 
     if is_pixeldata_encapsulated:
-        pixelData = pydicom3.encaps.encapsulate(raw_pixeldata, has_bot=include_bot)
+        pixelData = pydicom.encaps.encapsulate(raw_pixeldata, has_bot=include_bot)
     else:
         pixelData = bytes([item for sublist in raw_pixeldata for item in sublist])
 
@@ -206,7 +206,7 @@ def test_multiframe_raise_invalid_dicom_error(mocker: MockerFixture):
         include_eot=False,
         include_bot=False,
     )
-    mock_generate.side_effect = pydicom3.errors.InvalidDicomError("Test error")
+    mock_generate.side_effect = pydicom.errors.InvalidDicomError("Test error")
 
     get_multiframe_offset_tables(dataset)
 

--- a/cloud_optimized_dicom/tests/test_edit.py
+++ b/cloud_optimized_dicom/tests/test_edit.py
@@ -6,7 +6,7 @@ then reopens in mode='r' to verify the edits round-tripped correctly.
 
 import os
 
-import pydicom3
+import pydicom
 import pytest
 from google.cloud import storage
 
@@ -29,7 +29,7 @@ def test_edit_mode_happy_path(seeded_series: SeriesHandle):
         target = instances[0]
         target_uid_before = target.instance_uid()
         target_crc_before = target.crc32c()
-        ds = pydicom3.dcmread(target.dicom_uri)
+        ds = pydicom.dcmread(target.dicom_uri)
         ds.PatientName = new_patient_name
         ds.save_as(target.dicom_uri)
 
@@ -40,7 +40,7 @@ def test_edit_mode_happy_path(seeded_series: SeriesHandle):
         assert target_uid_before in after
         # crc32c of the edited instance differs from before
         assert after[target_uid_before].crc32c() != target_crc_before
-        edited_ds = pydicom3.dcmread(after[target_uid_before].dicom_uri)
+        edited_ds = pydicom.dcmread(after[target_uid_before].dicom_uri)
         assert str(edited_ds.PatientName) == new_patient_name
 
 
@@ -76,7 +76,7 @@ def test_edit_mode_corrupted_uid_raises(seeded_series: SeriesHandle):
     with pytest.raises(EditSetChangedError):
         with seeded_series.open(mode="e") as cod:
             first = next(iter(cod._get_instances(strict_sorting=False).values()))
-            ds = pydicom3.dcmread(first.dicom_uri)
+            ds = pydicom.dcmread(first.dicom_uri)
             ds.SOPInstanceUID = "1.2.3.4.5.6.7.8.9.1234567890"
             ds.save_as(first.dicom_uri)
 
@@ -108,7 +108,7 @@ def test_edit_mode_thumbnail_regen_on_pd_change(seeded_series: SeriesHandle):
 
     with seeded_series.open(mode="e") as cod:
         target = next(iter(cod._get_instances(strict_sorting=False).values()))
-        ds = pydicom3.dcmread(target.dicom_uri)
+        ds = pydicom.dcmread(target.dicom_uri)
         ds.PatientName = "REDACTED^REGEN^TEST"
         ds.save_as(target.dicom_uri)
 

--- a/cloud_optimized_dicom/tests/test_hashed_uids.py
+++ b/cloud_optimized_dicom/tests/test_hashed_uids.py
@@ -1,6 +1,6 @@
 from tempfile import NamedTemporaryFile
 
-import pydicom3
+import pydicom
 import pytest
 from google.cloud import storage
 
@@ -192,7 +192,7 @@ def test_append_diff_hash_dupe_with_hashed_uids(
     assert append_result.new[0] == instance
     # make a diff hash dupe
     with NamedTemporaryFile(suffix=".dcm") as f:
-        with pydicom3.dcmread(local_instance_path) as ds:
+        with pydicom.dcmread(local_instance_path) as ds:
             ds.add_new((0x1234, 0x5678), "DS", "12345678")
             ds.save_as(f.name)
         diff_hash_dupe = Instance(dicom_uri=f.name, uid_hash_func=example_hash_function)

--- a/cloud_optimized_dicom/tests/test_instance.py
+++ b/cloud_optimized_dicom/tests/test_instance.py
@@ -2,7 +2,7 @@ import os
 import tarfile
 import tempfile
 
-import pydicom3
+import pydicom
 import pytest
 
 from cloud_optimized_dicom.instance import Instance
@@ -21,14 +21,14 @@ def test_remote_detection(local_instance_path: str):
 def test_local_open(local_instance_path: str, test_instance_uid: str):
     instance = Instance(local_instance_path)
     with instance.open() as f:
-        ds = pydicom3.dcmread(f)
+        ds = pydicom.dcmread(f)
         assert ds.SOPInstanceUID == test_instance_uid
 
 
 def test_remote_open(test_instance_uid: str):
     instance = Instance(REMOTE_DICOM_URI)
     with instance.open() as f:
-        ds = pydicom3.dcmread(f)
+        ds = pydicom.dcmread(f)
         assert ds.SOPInstanceUID == test_instance_uid
 
 
@@ -84,7 +84,7 @@ def test_extract_metadata(local_instance_path: str, test_instance_uid: str):
 
 def test_extract_metadata_backfills_invalid_uid(local_instance_path: str):
     """Non-conformant UIDs (e.g. leading-zero components, >64 chars) are
-    dropped by pydicom3 when `to_json_dict(suppress_invalid_tags=True)`
+    dropped by pydicom when `to_json_dict(suppress_invalid_tags=True)`
     serializes under strict_reading. _backfill_missing_uids must reinsert
     them from the cached Instance fields populated by validate()."""
     bad_study_uid = "1.2.840.01.2.3"  # leading zero component
@@ -92,7 +92,7 @@ def test_extract_metadata_backfills_invalid_uid(local_instance_path: str):
     bad_sop_uid = "1." + "2" * 70  # >64 chars
 
     with tempfile.NamedTemporaryFile(suffix=".dcm") as tmp:
-        ds = pydicom3.dcmread(local_instance_path)
+        ds = pydicom.dcmread(local_instance_path)
         ds.StudyInstanceUID = bad_study_uid
         ds.SeriesInstanceUID = bad_series_uid
         ds.SOPInstanceUID = bad_sop_uid
@@ -142,14 +142,14 @@ def test_compress(local_instance_path: str):
     """Test that we can compress an instance to the given syntax"""
     instance = Instance(dicom_uri=local_instance_path)
     with instance.open() as f:
-        ds = pydicom3.dcmread(f)
-        assert ds.file_meta.TransferSyntaxUID == pydicom3.uid.ImplicitVRLittleEndian
+        ds = pydicom.dcmread(f)
+        assert ds.file_meta.TransferSyntaxUID == pydicom.uid.ImplicitVRLittleEndian
     uncompressed_size = instance.size()
     instance.compress()
     assert instance.size() < uncompressed_size
     with instance.open() as f:
-        ds = pydicom3.dcmread(f)
-        assert ds.file_meta.TransferSyntaxUID == pydicom3.uid.JPEG2000Lossless
+        ds = pydicom.dcmread(f)
+        assert ds.file_meta.TransferSyntaxUID == pydicom.uid.JPEG2000Lossless
     # Should be pointing to the new temp file
     assert instance._temp_file_path == instance.dicom_uri
     assert instance.dicom_uri != local_instance_path
@@ -167,7 +167,7 @@ def test_temp_file_cleanup(test_data_dir: str, test_instance_uid: str):
     assert instance._temp_file_path is not None
     # make sure we can read the instance
     with instance.open() as f:
-        ds = pydicom3.dcmread(f)
+        ds = pydicom.dcmread(f)
         assert ds.SOPInstanceUID == test_instance_uid
     # delete the instance - this should clean up the temp file
     del instance

--- a/cloud_optimized_dicom/tests/test_pydicom.py
+++ b/cloud_optimized_dicom/tests/test_pydicom.py
@@ -1,9 +1,0 @@
-def test_pydicom_version():
-    """
-    Test pydicom version concurrency - pydicom is 2.3.0 and pydicom3 is 3.1.0
-    """
-    import pydicom
-    import pydicom3
-
-    assert pydicom.__version__ == "2.3.0"
-    assert pydicom3.__version__ == "3.1.0"

--- a/cloud_optimized_dicom/tests/test_redact.py
+++ b/cloud_optimized_dicom/tests/test_redact.py
@@ -8,8 +8,8 @@ as expected.
 import os
 
 import numpy as np
-import pydicom3
-import pydicom3.examples
+import pydicom
+import pydicom.examples
 import pytest
 from google.cloud import storage
 
@@ -25,12 +25,12 @@ from cloud_optimized_dicom.instance import Instance
 from cloud_optimized_dicom.tests.conftest import SeriesHandle
 
 
-def _read_remote_dataset(handle: SeriesHandle, instance_uid: str) -> pydicom3.Dataset:
+def _read_remote_dataset(handle: SeriesHandle, instance_uid: str) -> pydicom.Dataset:
     """Pull the series tar fresh from GCS and return the named instance as a Dataset."""
     with handle.open(mode="r") as cod:
         cod.extract_locally()
         instance = cod._get_instance(instance_uid)
-        return pydicom3.dcmread(instance.dicom_uri)
+        return pydicom.dcmread(instance.dicom_uri)
 
 
 def _read_remote_pixel_array(handle: SeriesHandle, instance_uid: str) -> np.ndarray:
@@ -64,7 +64,7 @@ def ybr_full_422_path() -> str:
     pydicom's bundled example set rather than committed to this repo: pydicom
     documents `examples.ybr_color` as part of the package itself (not the
     on-demand download set), so it ships with every pydicom install."""
-    return str(pydicom3.examples.get_path("ybr_color"))
+    return str(pydicom.examples.get_path("ybr_color"))
 
 
 @pytest.fixture

--- a/cloud_optimized_dicom/tests/test_thumbnail.py
+++ b/cloud_optimized_dicom/tests/test_thumbnail.py
@@ -3,8 +3,8 @@ import os
 import tempfile
 
 import numpy as np
-import pydicom3
-import pydicom3.encaps
+import pydicom
+import pydicom.encaps
 import pytest
 from google.cloud import storage
 
@@ -400,7 +400,7 @@ def test_series_missing_pixel_data_error(
     # Create a DICOM file without pixel data by reading an existing file
     # and removing the pixel data
     dicom_path = os.path.join(test_data_dir, "monochrome1.dcm")
-    ds = pydicom3.dcmread(dicom_path)
+    ds = pydicom.dcmread(dicom_path)
 
     # Remove pixel data
     if hasattr(ds, "PixelData"):

--- a/cloud_optimized_dicom/thumbnail.py
+++ b/cloud_optimized_dicom/thumbnail.py
@@ -6,9 +6,9 @@ from typing import TYPE_CHECKING, Tuple
 import cv2
 import ffmpeg
 import numpy as np
-import pydicom3
+import pydicom
 from google.cloud import storage
-from pydicom3.pixels import (
+from pydicom.pixels import (
     apply_color_lut,
     apply_modality_lut,
     apply_voi_lut,
@@ -112,7 +112,7 @@ def _resize(frame: np.ndarray, max_dim=128) -> np.ndarray:
 
 def _apply_pydicom_handling(
     frame: np.ndarray,
-    ds: pydicom3.Dataset,
+    ds: pydicom.Dataset,
     apply_modality=True,
     apply_voi=True,
     apply_window=True,
@@ -184,7 +184,7 @@ def _apply_pydicom_handling(
 
 
 def _normalize_and_convert(
-    frame: np.ndarray, ds: pydicom3.Dataset, invert_monochrome1: bool = True
+    frame: np.ndarray, ds: pydicom.Dataset, invert_monochrome1: bool = True
 ) -> np.ndarray:
     """Performs the following operations in sequence:
         1) Normalize the frame between 0 and 255
@@ -225,7 +225,7 @@ def _normalize_and_convert(
 
 def _convert_to_bgr(frame: np.ndarray) -> np.ndarray:
     """Convert a frame to BGR (what openCV expects).
-    Note: For multi-sample data, we assume the frame is in RGB format, which it should be because pydicom3.iter_pixels converts YBR to RGB.
+    Note: For multi-sample data, we assume the frame is in RGB format, which it should be because pydicom.iter_pixels converts YBR to RGB.
 
     Returns:
         A numpy array of the frame in BGR format.
@@ -322,7 +322,7 @@ def _pad(
 
 
 def _generate_thumbnail_frame_and_anchors(
-    frame: np.ndarray, ds: pydicom3.Dataset, thumbnail_size: int
+    frame: np.ndarray, ds: pydicom.Dataset, thumbnail_size: int
 ) -> Tuple[np.ndarray, dict]:
     """
     Given a DICOM frame (from `pydicom.pixels.iter_pixels`), create a thumbnail and record
@@ -401,9 +401,9 @@ def _generate_thumbnail_frames(
     thumbnail_index_to_instance_frame = []
     for instance_uid, instance in uid_to_instance.items():
         with instance.open() as f:
-            ds = pydicom3.dcmread(f, defer_size=1024)
+            ds = pydicom.dcmread(f, defer_size=1024)
             instance_frame_metadata = []
-            for instance_frame_index, frame in enumerate(pydicom3.iter_pixels(ds)):
+            for instance_frame_index, frame in enumerate(pydicom.iter_pixels(ds)):
                 thumbnail_frame, anchors = _generate_thumbnail_frame_and_anchors(
                     frame, ds, thumbnail_size
                 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "pylibjpeg==2.1.0",
     "pylibjpeg-libjpeg==2.4.0",
     "pylibjpeg-openjpeg==2.5.0",
-    "pydicom3>=3.1.0",
+    "pydicom>=3.0",
     "opencv-python-headless==4.13.0.92",
     "ffmpeg-python==0.2.0",
     "zstandard>=0.24.0",
@@ -39,7 +39,6 @@ beam = [
     "apache-beam[gcp]==2.73.0",
 ]
 test = [
-    "pydicom==2.3.0",
     "matplotlib",
     "pytest>=8.0.0",
     "pytest-mock>=3.12.0",
@@ -47,7 +46,6 @@ test = [
 ]
 dev = [
     "pre-commit>=3.0.0",
-    "pydicom==2.3.0",
     "matplotlib",
     "apache-beam[gcp]==2.73.0",
     "pytest>=8.0.0",


### PR DESCRIPTION
## Summary

Drops the `gradienthealth/pydicom-3` fork in favor of upstream `pydicom>=3.0` so cod and gradient-beam can stop installing two pydicoms side-by-side (cross-boundary `isinstance(ds, pydicom.Dataset)` was silently failing on objects constructed inside cod). Both carried fork patches are dropped: the lenient sequence-parse in `filereader` (confirmed dead by the Cloud Logging sweep) is just deleted, and the `LOGGER.exception` suppression in `pixels/decoders/base._decode_frame` is reproduced by a small `logging.Filter` in `cloud_optimized_dicom/config.py`. Upstream pydicom 3 regenerates the SOP Instance UID inside `Dataset.compress()` by default, so `instance.compress()` and `redact.compress()` now pass `generate_instance_uid=False` to keep COD's UID-keyed metadata and `mode='e'` set validation intact. The `pydicom==2.3.0` test pin is removed since it would conflict with upstream pydicom 3 in the same namespace; the now-obsolete `test_pydicom.py` version-concurrency test is deleted along with it.

## Test plan
- [x] `SISKIN_ENV_ENABLED=1 pytest` — 146 passed, 1 skipped
- [x] pre-commit (autoflake / isort / black) clean
- [ ] Confirm release-please proposes a major bump (BREAKING CHANGE footer) and that the gradient-beam follow-up in PROC-1617 picks up the new version

BREAKING CHANGE: cloud_optimized_dicom now depends on upstream `pydicom>=3.0` instead of the `pydicom3` fork. Downstream impact:

- `isinstance` checks against `pydicom3.*` on cod-returned objects will start returning `False` — switch to `pydicom.*`. (This is exactly the bug PROC-1668 fixes for gradient-beam.)
- Installing `cloud-optimized-dicom` no longer transitively installs `pydicom3`. Code that imported `pydicom3` only because cod brought it in must either switch to `import pydicom` or add the fork to its own dependencies.
- Environments pinned to `pydicom<3` will no longer resolve. Bump to `pydicom>=3.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)