### PR TITLE
fix(PROC-1669): relax google-cloud-storage and apache-beam pins

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "smart-open==7.6.0",
     "ratarmountcore==0.10.4",
     "numpy",
-    "google-cloud-storage==3.10.1",
+    "google-cloud-storage>=2.18.2,<4",
     "filetype==1.2.0",
     "pylibjpeg==2.1.0",
     "pylibjpeg-libjpeg==2.4.0",
@@ -36,7 +36,7 @@ dependencies = [
 
 [project.optional-dependencies]
 beam = [
-    "apache-beam[gcp]==2.73.0",
+    "apache-beam[gcp]>=2.63.0,<3",
 ]
 test = [
     "matplotlib",
@@ -47,7 +47,7 @@ test = [
 dev = [
     "pre-commit>=3.0.0",
     "matplotlib",
-    "apache-beam[gcp]==2.73.0",
+    "apache-beam[gcp]>=2.63.0,<3",
     "pytest>=8.0.0",
     "pytest-mock>=3.12.0",
     "pytest-xdist>=3.6.0",


### PR DESCRIPTION
## Summary
- Relax `google-cloud-storage==3.10.1` → `>=2.18.2,<4` (matches apache-beam's floor)
- Relax `apache-beam[gcp]==2.73.0` → `>=2.63.0,<3` (in both `[beam]` and `[dev]` extras)

## Why
cod 2.0.0's exact pins block gradient-beam from picking up the new release: gradient-beam pins `apache-beam[gcp]==2.63.0`, which transitively caps `google-cloud-storage<3`, so neither cod pin is satisfiable without forcing a Beam SDK upgrade. That upgrade is real work (Dataflow worker images, ~15 transitive package changes, prerelease `betterproto`) and shouldn't be smuggled in alongside the pydicom-fork-retirement work.

cod 2.0.0 isn't consumed in production yet, so relaxing both pins doesn't break any existing downstream. The only Beam API used in cod is `apache_beam.metrics.Metrics.counter` (`cloud_optimized_dicom/metrics.py`), which has been stable well before 2.63.0.

This will release as cod 2.0.1.

## Test plan
- [ ] CI green
- [ ] Add cod 2.0.1 to a gradient-beam branch and confirm `uv lock` succeeds without a Beam SDK upgrade (per acceptance criteria in PROC-1669)

🤖 Generated with [Claude Code](https://claude.com/claude-code)