### PR TITLE
fix(PROC-1688): silence ratarmountcore print noise in batch logs

### DIFF
--- a/cloud_optimized_dicom/config.py
+++ b/cloud_optimized_dicom/config.py
@@ -64,3 +64,7 @@ class _DecodeFrameExceptionFilter(logging.Filter):
 logging.getLogger("pydicom.pixels.decoders.base").addFilter(
     _DecodeFrameExceptionFilter()
 )
+
+
+# Silence ratarmountcore 0.10.x bare `print()` calls gated on `isEnabledFor(WARNING)`.
+logging.getLogger("ratarmountcore").setLevel(logging.ERROR)


### PR DESCRIPTION
Batch task logs are getting flooded by `print()` calls inside `ratarmountcore` 0.10.x (e.g. `Creating offset dictionary for ...`, `Creating new SQLite index database at ...`) on every TAR open. These are bare `print()` statements gated only on `logger.isEnabledFor(WARNING)`, so they bypass `logging` entirely and can't be filtered by gradient-beam's `StructuredLogHandler`. The regression entered in #123, which bumped ratarmountcore 0.7.1 → 0.10.4.

- Raise the `ratarmountcore` logger to `ERROR` in `cloud_optimized_dicom/config.py`, closing the `isEnabledFor(WARNING)` gate at import time so every COD consumer inherits the suppression.

Trade-off: this also drops genuine `logger.warning(...)` calls from ratarmountcore; `logger.error(...)` still propagates. Silencing the prints any other way would require monkey-patching, since they aren't routed through `logging`. A follow-up upstream PR asking ratarmountcore to switch these to `logger.info(...)` is worth filing.