### PR TITLE
fix(PROC-1735): read crc32c hint as crc32c_hash

### DIFF
--- a/cloud_optimized_dicom/query_parsing.py
+++ b/cloud_optimized_dicom/query_parsing.py
@@ -47,7 +47,7 @@ def query_result_to_instances(
             )
         hints = Hints(
             size=file.get("size"),
-            crc32c=file.get("crc32c"),
+            crc32c=file.get("crc32c_hash"),
             instance_uid=file.get("instance_uid"),
             study_uid=study_uid,
             series_uid=series_uid,

--- a/cloud_optimized_dicom/tests/test_concat.py
+++ b/cloud_optimized_dicom/tests/test_concat.py
@@ -75,7 +75,7 @@ def concat_paths(gcs_client: storage.Client, worker_namespace: str) -> ConcatPat
                 f"{INSTANCE_UIDS[idx]}{name_suffix}.dcm"
             ),
             "size": FILE_SIZES[idx],
-            "crc32c": FILE_CRC32CS[idx],
+            "crc32c_hash": FILE_CRC32CS[idx],
             "instance_uid": INSTANCE_UIDS[idx],
         }
 


### PR DESCRIPTION
`query_result_to_instances` was reading the crc32c hint as `file.get("crc32c")`, but every BigQuery row produced by callers (e.g. `gradient-beam`'s `gcs/io.py::generate_query` and its README examples) aliases the column as `crc32c_hash`. The hint was silently `None` on every input row.

For NEW instances this is invisible (`validate()` fetches the blob and populates `_crc32c` itself). The bug surfaces on re-ingest of SAME/DUPLICATE-bucket rows when `--delete-originals-on-success` already removed the originals: `validate()` raises `NotFound`, downstream `ManifestRow.from_instance` in `gradient-beam` drops the row, and "pending" never converges.

- `cloud_optimized_dicom/query_parsing.py`: read the crc32c hint as `crc32c_hash` to match the documented query convention.
- `cloud_optimized_dicom/tests/test_concat.py`: update the test fixture's `_file()` to emit `crc32c_hash`, so the hint still flows through the parser.

Related: PROC-1732, PROC-1734 (gradient-beam side of the same incident and the per-pipeline workaround already shipped there).