### PR TITLE
fix(PROC-1927): respect compress flag in _handle_new

### DIFF
--- a/cloud_optimized_dicom/append.py
+++ b/cloud_optimized_dicom/append.py
@@ -457,7 +457,12 @@ def _handle_new(
         [new for new, _, _ in new_state_changes]
     )
     # Step 2: compress instances (if specified)
-    compressed_instances, compression_errors = _compress_instances(validated_instances)
+    if compress:
+        compressed_instances, compression_errors = _compress_instances(
+            validated_instances
+        )
+    else:
+        compressed_instances, compression_errors = validated_instances, []
 
     if not compressed_instances:
         logger.warning(

--- a/cloud_optimized_dicom/tests/test_appender.py
+++ b/cloud_optimized_dicom/tests/test_appender.py
@@ -476,3 +476,34 @@ def test_append_compress(
         ds = pydicom.dcmread(f)
         assert ds.file_meta.TransferSyntaxUID == pydicom.uid.JPEG2000Lossless
     assert instance.size() < uncompressed_size
+
+
+def test_append_no_compress(
+    gcs_client: storage.Client,
+    datastore_path: str,
+    local_instance_path: str,
+    test_study_uid: str,
+    test_series_uid: str,
+):
+    """test that compress=False preserves the original transfer syntax (PROC-1927)"""
+    cod_obj = CODObject(
+        client=gcs_client,
+        datastore_path=datastore_path,
+        study_uid=test_study_uid,
+        series_uid=test_series_uid,
+        mode="w",
+        sync_on_exit=False,
+    )
+    instance = Instance(dicom_uri=local_instance_path)
+    with instance.open() as f:
+        ds = pydicom.dcmread(f)
+        assert ds.file_meta.TransferSyntaxUID == pydicom.uid.ImplicitVRLittleEndian
+    uncompressed_size = instance.size()
+    new, same, conflict, errors = cod_obj.append([instance], compress=False)
+    assert len(new) == 1
+    assert len(same + conflict + errors) == 0
+    # uncompressed: transfer syntax and size are unchanged
+    assert instance.size() == uncompressed_size
+    with instance.open() as f:
+        ds = pydicom.dcmread(f)
+        assert ds.file_meta.TransferSyntaxUID == pydicom.uid.ImplicitVRLittleEndian


### PR DESCRIPTION
The `compress` flag is plumbed from `runner.py` (`--compression-mode=PRESERVE` → `compress=False`) through `ingest_instances` → `_handle_new`, but was then dropped: `_handle_new` called `_compress_instances()` unconditionally, making `--compression-mode=PRESERVE` a no-op. Any caller wanting to skip JPEG2000 encoding (e.g. DICOMs whose pixel data won't encode cleanly) hit compression errors regardless.

- Gate the `_compress_instances()` call in `_handle_new` on the `compress` flag; when `False`, instances pass through validated-but-untranscoded with no compression errors.
- Add `test_append_no_compress` asserting `compress=False` preserves the original transfer syntax and file size.

Surfaced while seeding the `gh-laplace-combo` test environment, where 16×16 noise frames openjpeg can't encode and `PRESERVE` failed to escape compression. A local patch of this shape on Cal's laptop should be reverted once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)